### PR TITLE
SF #1930 Mail to Ticket: improved parsing of from: address

### DIFF
--- a/classes/rawemailmessage.class.inc.php
+++ b/classes/rawemailmessage.class.inc.php
@@ -907,20 +907,15 @@ class RawEmailMessage
 	protected static function ExtractAddressPieces($sAddress)
 	{
 		$sAddress = trim($sAddress);
-		if (preg_match('/^(.*)<([^ ]+)>$/', $sAddress, $aMatches))
-		{
-			$sName = trim($aMatches[1], ' "');
-			$sEmail = $aMatches[2];
-		}
 		// In a rare circumstance, an email From: header looked like this:
 		// From: "Firstname Lastname" <firstname.lastname@domain.com >
 		// The client was Windows Live Mail, but it seems the email address was somehow misconfigured while still able to send emails.
 		// This fix still processes invalid From: headers where there are spaces before or after the email address.
 		// This regex is quite strict to prevent other issues from occurring because of this fix.
-		elseif(preg_match('/^(.*)<([ ]{0,})([^ ]+@[^ ]+\.[^ ]+)([ ]{0,})>$/', $sAddress, $aMatches))
+		if(preg_match('/^(.*)<\s*([^ ]+@[^ ]+\.[^ ]+)\s*>$/', $sAddress, $aMatches))
 		{
 			$sName = trim($aMatches[1], ' "');
-			$sEmail = $aMatches[3];
+			$sEmail = $aMatches[2];
 		}
 		else
 		{

--- a/classes/rawemailmessage.class.inc.php
+++ b/classes/rawemailmessage.class.inc.php
@@ -912,6 +912,16 @@ class RawEmailMessage
 			$sName = trim($aMatches[1], ' "');
 			$sEmail = $aMatches[2];
 		}
+		// In a rare circumstance, an email From: header looked like this:
+		// From: "Firstname Lastname" <firstname.lastname@domain.com >
+		// The client was Windows Live Mail, but it seems the email address was somehow misconfigured while still able to send emails.
+		// This fix still processes invalid From: headers where there are spaces before or after the email address.
+		// This regex is quite strict to prevent other issues from occurring because of this fix.
+		elseif(preg_match('/^(.*)<([ ]{0,})([^ ]+@[^ ]+\.[^ ]+)([ ]{0,})>$/', $sAddress, $aMatches))
+		{
+			$sName = trim($aMatches[1], ' "');
+			$sEmail = $aMatches[3];
+		}
 		else
 		{
 			if (preg_match('/^([^ ]+) ?\((.*)\)$/', $sAddress, $aMatches))

--- a/classes/rawemailmessage.class.inc.php
+++ b/classes/rawemailmessage.class.inc.php
@@ -912,7 +912,7 @@ class RawEmailMessage
 		// The client was Windows Live Mail, but it seems the email address was somehow misconfigured while still able to send emails.
 		// This fix still processes invalid From: headers where there are spaces before or after the email address.
 		// This regex is quite strict to prevent other issues from occurring because of this fix.
-		if(preg_match('/^(.*)<\s*([^ ]+@[^ ]+\.[^ ]+)\s*>$/', $sAddress, $aMatches))
+		if(preg_match('/^(.*)<\s*(.+?)\s*>$/', $sAddress, $aMatches))
 		{
 			$sName = trim($aMatches[1], ' "');
 			$sEmail = $aMatches[2];

--- a/test/TestEmlFiles.php
+++ b/test/TestEmlFiles.php
@@ -1,21 +1,8 @@
 <?php
-// Copyright (c) 2010-2020 Combodo SARL
-//
-//   This file is part of iTop.
-//
-//   iTop is free software; you can redistribute it and/or modify
-//   it under the terms of the GNU Affero General Public License as published by
-//   the Free Software Foundation, either version 3 of the License, or
-//   (at your option) any later version.
-//
-//   iTop is distributed in the hope that it will be useful,
-//   but WITHOUT ANY WARRANTY; without even the implied warranty of
-//   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//   GNU Affero General Public License for more details.
-//
-//   You should have received a copy of the GNU Affero General Public License
-//   along with iTop. If not, see <http://www.gnu.org/licenses/>
-//
+/*
+ * @copyright   Copyright (C) 2010-2021 Combodo SARL
+ * @license     http://opensource.org/licenses/AGPL-3.0
+ */
 
 
 namespace Combodo\iTop\Test\UnitTest\CombodoEmailSynchro;
@@ -23,14 +10,21 @@ namespace Combodo\iTop\Test\UnitTest\CombodoEmailSynchro;
 use Combodo\iTop\Test\UnitTest\ItopTestCase;
 use RawEmailMessage;
 
-class RawEmailMessageTest extends ItopTestCase
+/**
+ * Class TestEmlFiles
+ *
+ * Use EML files in `/test/emailsSample`
+ *
+ * @package Combodo\iTop\Test\UnitTest\CombodoEmailSynchro
+ */
+class TestEmlFiles extends ItopTestCase
 {
 
 	public function setUp()
 	{
 		parent::setUp();
 
-		require_once(APPROOT . 'env-production/combodo-email-synchro/classes/rawemailmessage.class.inc.php');
+		require_once(APPROOT.'env-production/combodo-email-synchro/classes/rawemailmessage.class.inc.php');
 	}
 
 	/**

--- a/test/classes/RawEmailMessageTest.php
+++ b/test/classes/RawEmailMessageTest.php
@@ -1,0 +1,83 @@
+<?php
+/*
+ * @copyright   Copyright (C) 2010-2021 Combodo SARL
+ * @license     http://opensource.org/licenses/AGPL-3.0
+ */
+
+
+use Combodo\iTop\Test\UnitTest\ItopTestCase;
+
+class RawEmailMessageTest extends ItopTestCase
+{
+	public function setUp()
+	{
+		parent::setUp();
+
+		require_once(APPROOT.'env-production/combodo-email-synchro/classes/rawemailmessage.class.inc.php');
+	}
+
+	/**
+	 * @dataProvider ExtractAddressPiecesProvider
+	 * @covers       \RawEmailMessage::ExtractAddressPieces()
+	 *
+	 * @param string $sSourceAddressString
+	 * @param string $sExpectedName
+	 * @param string $sExpectedEmail
+	 *
+	 * @throws \ReflectionException
+	 */
+	public function testExtractAddressPieces(string $sSourceAddressString, string $sExpectedName, string $sExpectedEmail): void
+	{
+		$oReflector = new \ReflectionClass(RawEmailMessage::class);
+		$oMethod = $oReflector->getMethod('ExtractAddressPieces');
+		$oMethod->setAccessible(true);
+		$aAddressParts = $oMethod->invoke(null, $sSourceAddressString);
+
+		$this->assertCount(2, $aAddressParts, 'method should return 2 results');
+		$this->assertArrayHasKey('name', $aAddressParts, 'Result must contain the "name" key');
+		$this->assertArrayHasKey('email', $aAddressParts, 'Result must contain the "email" key');
+		$this->assertEquals($sExpectedName, $aAddressParts['name'], 'Name different than expected');
+		$this->assertEquals($sExpectedEmail, $aAddressParts['email'], 'Email different than expected');
+	}
+
+	public function ExtractAddressPiecesProvider(): array
+	{
+		return [
+			'simple email' => [
+				'$sSourceAddressString' => 'name@domain.com',
+				'$sExpectedName' => '',
+				'$sExpectedEmail' => 'name@domain.com',
+			],
+			'simple email but invalid' => [
+				'$sSourceAddressString' => 'name @domain.com',
+				'$sExpectedName' => '',
+				'$sExpectedEmail' => 'name @domain.com',
+			],
+			'name + email' => [
+				'$sSourceAddressString' => 'Firstname Lastname <name@domain.com>',
+				'$sExpectedName' => 'Firstname Lastname',
+				'$sExpectedEmail' => 'name@domain.com',
+			],
+			'name + email, email invalid' => [
+				'$sSourceAddressString' => 'Firstname Lastname <name @domain.com>',
+				'$sExpectedName' => 'Firstname Lastname',
+				'$sExpectedEmail' => 'name @domain.com',
+			],
+			'name + email : space before closing angled bracket' => [
+				'$sSourceAddressString' => 'Firstname Lastname <name@domain.com >',
+				'$sExpectedName' => 'Firstname Lastname',
+				'$sExpectedEmail' => 'name@domain.com',
+			],
+			'name + email : double quotes' => [
+				'$sSourceAddressString' => '"Firstname Lastname" <name@domain.com>',
+				'$sExpectedName' => 'Firstname Lastname',
+				'$sExpectedEmail' => 'name@domain.com',
+			],
+			'name + email : double quotes + space before closing angled bracket' => [
+				'$sSourceAddressString' => '"Firstname Lastname" <name@domain.com >',
+				'$sExpectedName' => 'Firstname Lastname',
+				'$sExpectedEmail' => 'name@domain.com',
+			],
+		];
+	}
+}

--- a/test/classes/RawEmailMessageTest.php
+++ b/test/classes/RawEmailMessageTest.php
@@ -25,16 +25,10 @@ class RawEmailMessageTest extends ItopTestCase
 	 * @param string $sSourceAddressString
 	 * @param string $sExpectedName
 	 * @param string $sExpectedEmail
-	 *
-	 * @throws \ReflectionException
 	 */
 	public function testExtractAddressPieces(string $sSourceAddressString, string $sExpectedName, string $sExpectedEmail): void
 	{
-		//FIXME use instead \Combodo\iTop\Test\UnitTest\ItopTestCase::InvokeNonPublicStaticMethod (will be merged in develop soon)
-		$oReflector = new \ReflectionClass(RawEmailMessage::class);
-		$oMethod = $oReflector->getMethod('ExtractAddressPieces');
-		$oMethod->setAccessible(true);
-		$aAddressParts = $oMethod->invoke(null, $sSourceAddressString);
+		$aAddressParts = $this->InvokeNonPublicStaticMethod(RawEmailMessage::class, 'ExtractAddressPieces', [$sSourceAddressString]);
 
 		$this->assertCount(2, $aAddressParts, 'method should return 2 results');
 		$this->assertArrayHasKey('name', $aAddressParts, 'Result must contain the "name" key');

--- a/test/classes/RawEmailMessageTest.php
+++ b/test/classes/RawEmailMessageTest.php
@@ -4,8 +4,10 @@
  * @license     http://opensource.org/licenses/AGPL-3.0
  */
 
+namespace Combodo\iTop\Test\UnitTest\CombodoEmailSynchro;
 
 use Combodo\iTop\Test\UnitTest\ItopTestCase;
+use RawEmailMessage;
 
 class RawEmailMessageTest extends ItopTestCase
 {
@@ -28,7 +30,7 @@ class RawEmailMessageTest extends ItopTestCase
 	 */
 	public function testExtractAddressPieces(string $sSourceAddressString, string $sExpectedName, string $sExpectedEmail): void
 	{
-		//FIXME use instead \Combodo\iTop\Test\UnitTest\ItopTestCase::InvokeInvisibleStaticMethod (will be merged in develop soon)
+		//FIXME use instead \Combodo\iTop\Test\UnitTest\ItopTestCase::InvokeNonPublicStaticMethod (will be merged in develop soon)
 		$oReflector = new \ReflectionClass(RawEmailMessage::class);
 		$oMethod = $oReflector->getMethod('ExtractAddressPieces');
 		$oMethod->setAccessible(true);

--- a/test/classes/RawEmailMessageTest.php
+++ b/test/classes/RawEmailMessageTest.php
@@ -28,6 +28,7 @@ class RawEmailMessageTest extends ItopTestCase
 	 */
 	public function testExtractAddressPieces(string $sSourceAddressString, string $sExpectedName, string $sExpectedEmail): void
 	{
+		//FIXME use instead \Combodo\iTop\Test\UnitTest\ItopTestCase::InvokeInvisibleStaticMethod (will be merged in develop soon)
 		$oReflector = new \ReflectionClass(RawEmailMessage::class);
 		$oMethod = $oReflector->getMethod('ExtractAddressPieces');
 		$oMethod->setAccessible(true);


### PR DESCRIPTION
Not sure whether this will be accepted, as I assume it's misconfiguration on the sender's part.

Anyhow, it's based on a real life case from about a week ago.

In a rare circumstance, an email From: header looked like this:  
`From: "Firstname Lastname" <firstname.lastname@domain.com >`

The client was Windows Live Mail, but it seems the email address was somehow misconfigured while still able to send emails.
This fix still processes invalid From: headers where there are spaces before or after the email address.
This regex is quite strict to prevent other issues from occurring because of this fix.