### PR TITLE
SF #1925 Mail to Ticket: malformed headers 

### DIFF
--- a/classes/imapemailsource.class.inc.php
+++ b/classes/imapemailsource.class.inc.php
@@ -79,7 +79,20 @@ class IMAPEmailSource extends EmailSource
 	 */
 	public function GetMessage($index)
 	{
-		$sRawHeaders = imap_fetchheader($this->rImapConn, 1+$index);
+		$sRawHeaders = imap_fetchheader($this->rImapConn, 1+$index);        
+		// Rare occurrence of e-mails from 2010/2011, from VirginMedia, sent by an unknown client.
+		// To: <Undisclosed-Recipient:;>
+		$sLastError = imap_last_error();
+		if($sLastError !== false)
+		{
+			if(preg_match('/Unexpected characters at end of address: <(.*)>/', $sLastError, $aMatches))
+			{
+				// Exception occurred while parsing From, To, CC headers.
+				// It's not necessarily critical, because the problem can be located just in one single address.
+				// Drop this warning.
+				imap_errors();
+			}
+		}
 		$sBody = imap_body($this->rImapConn, 1+$index, FT_PEEK);
 		$aOverviews = imap_fetch_overview($this->rImapConn, 1+$index);
 		$oOverview = array_pop($aOverviews);

--- a/classes/imapemailsource.class.inc.php
+++ b/classes/imapemailsource.class.inc.php
@@ -79,7 +79,7 @@ class IMAPEmailSource extends EmailSource
 	 */
 	public function GetMessage($index)
 	{
-		$sRawHeaders = imap_fetchheader($this->rImapConn, 1+$index);        
+		$sRawHeaders = imap_fetchheader($this->rImapConn, 1+$index);
 		// Rare occurrence of e-mails from 2010/2011, from VirginMedia, sent by an unknown client.
 		// To: <Undisclosed-Recipient:;>
 		$sLastError = imap_last_error();


### PR DESCRIPTION
Another issue I recently saw, while testing with old emails (2010/2011) sent to me, was that the "to:" field could actually contain things like "undisclosed recipient" instead of a proper email address. This results in PHP notices, also on the AJAX page.

Would a pull request be accepted for this rare issue where these warnings are simply suppressed?
