### PR TITLE
SF #1859 Mail to Ticket Automation - issue with long subjects

### DIFF
--- a/classes/rawemailmessage.class.inc.php
+++ b/classes/rawemailmessage.class.inc.php
@@ -582,7 +582,8 @@ class RawEmailMessage
 			{
 				if (isset($aRawFields[$sCurrentHeader]))
 				{
-					$aRawFields[$sCurrentHeader] .= substr($sLine, 1);
+					// Fix for long subjects where spaces get lost on split header lines.
+					$aRawFields[$sCurrentHeader] .= (in_array($sCurrentHeader, array('references', 'subject')) ? $sLine : substr($sLine, 1));
 				}
 			}
 			$idx++;


### PR DESCRIPTION
Fixes issue with long subjects and references (multiline in EML).
Actually might need to be applied to all header lines and not just "subject" and "references", but I had no reason to further investigate this.