### PR TITLE
SF #1793 Mail to Ticket Automation: set IMAP undelete

### DIFF
--- a/classes/emailbackgroundprocess.class.inc.php
+++ b/classes/emailbackgroundprocess.class.inc.php
@@ -225,6 +225,13 @@ class EmailBackgroundProcess implements iBackgroundProcess
 
 						try
 						{
+							
+							if($oSource instanceof IMAPEmailSource)
+							{
+								// Prevents IMAP email messages that were marked for deletion before (but restored through recovered items) from being deleted again
+								$ret = $oSource->UndeleteMessage($iMessage);
+							}
+							
 							$this->InitMessageTrace($oSource, $iMessage);
 							$iTotalMessages++;
 							if (self::IsMultiSourceMode())

--- a/classes/emailbackgroundprocess.class.inc.php
+++ b/classes/emailbackgroundprocess.class.inc.php
@@ -226,12 +226,8 @@ class EmailBackgroundProcess implements iBackgroundProcess
 						try
 						{
 							
-							if($oSource instanceof IMAPEmailSource)
-							{
-								// Prevents IMAP email messages that were marked for deletion before (but restored through recovered items) from being deleted again
-								$ret = $oSource->UndeleteMessage($iMessage);
-							}
-							
+							$oSource->InitMessage($iMessage);
+							 
 							$this->InitMessageTrace($oSource, $iMessage);
 							$iTotalMessages++;
 							if (self::IsMultiSourceMode())

--- a/classes/emailsource.class.inc.php
+++ b/classes/emailsource.class.inc.php
@@ -48,6 +48,13 @@ abstract class EmailSource
 	abstract public function GetMessage($index);
 
 	/**
+	 * Initializes the message when it is being processed.
+	 * @param $index integer The index between zero and count
+	 * @return void
+	 */
+	abstract public function InitMessage($index);
+	
+	/**
 	 * Deletes the message of the given index [0..Count] from the mailbox
 	 * @param $index integer The index between zero and count
 	 */

--- a/classes/imapemailsource.class.inc.php
+++ b/classes/imapemailsource.class.inc.php
@@ -109,8 +109,18 @@ class IMAPEmailSource extends EmailSource
 	 public function GetName()
 	 {
 	 	return $this->sLogin;
-	 }
-
+	 
+	 
+	/**
+	 * Marks the message for undeletion (IMAP-flag) of the given index [0..Count] from the mailbox.
+	 * @param $index integer The index between zero and count
+	 */
+	public function UndeleteMessage($index)
+	{
+		$ret = imap_undelete($this->rImapConn, (1+$index).':'.(1+$index));
+		return $ret;
+	}
+	
 	/**
 	 * Mailbox path of the eMail source
 	 */

--- a/classes/imapemailsource.class.inc.php
+++ b/classes/imapemailsource.class.inc.php
@@ -61,6 +61,20 @@ class IMAPEmailSource extends EmailSource
 	}	
 
 	/**
+	 * Initializes the message when it is being processed.
+	 * @param $index integer The index between zero and count
+	 * @return void
+	 */
+	public function InitMessage($index)
+	{
+		
+		// Preventive measure. For restored emails, sometimes there's still an IMAP flag indicating it was 'marked for removal'.
+		$this->UndeleteMessage($index);
+		
+		return;
+	}
+	
+	/**
 	 * Get the number of messages to process
 	 * @return integer The number of available messages
 	 */

--- a/classes/imapemailsource.class.inc.php
+++ b/classes/imapemailsource.class.inc.php
@@ -104,14 +104,6 @@ class IMAPEmailSource extends EmailSource
 	}
 	
 	/**
-	 * Name of the eMail source
-	 */
-	 public function GetName()
-	 {
-	 	return $this->sLogin;
-	 
-	 
-	/**
 	 * Marks the message for undeletion (IMAP-flag) of the given index [0..Count] from the mailbox.
 	 * @param $index integer The index between zero and count
 	 */
@@ -120,6 +112,15 @@ class IMAPEmailSource extends EmailSource
 		$ret = imap_undelete($this->rImapConn, (1+$index).':'.(1+$index));
 		return $ret;
 	}
+	
+	/**
+	 * Name of the eMail source
+	 */
+	public function GetName()
+	{
+		return $this->sLogin;
+	}
+	 
 	
 	/**
 	 * Mailbox path of the eMail source


### PR DESCRIPTION
While debugging my own version of Mail to Ticket Automation; I stumbled upon something that may happen in obscure cases. Let's say for some reason emails were recovered from deleted folders in an IMAP source (for example: email got accidentally deleted because of an IMAP process).

Couldn't figure out why the email kept disappearing, despite commenting out all DeleteMessage() references. Turns out the deletion happened on disconnecting of the IMAP source. There, it closes the source with CL_EXPUNGE. However, when emails are restored from the recycle bin, apparently they keep the "marked for deletion" flag.