### PR TITLE
Rename settings (consistency)

### DIFF
--- a/classes/emailmessage.class.inc.php
+++ b/classes/emailmessage.class.inc.php
@@ -217,7 +217,7 @@ class EmailMessage {
 	/**
 	 * When the message is a reply or forward of another message, this method
 	 * (tries to) extract the "new" part of the body in HTML, producing some HTML
-	 * as the output. The filtering is based on a list of tags/classes to remove (overrideable by 'html-tags-to-remove' in the config)
+	 * as the output. The filtering is based on a list of tags/classes to remove (overrideable by 'html_tags_to_remove' in the config)
 	 */
 	public function GetNewPartHTML($sBodyText = null)
 	{
@@ -242,7 +242,7 @@ class EmailMessage {
 
 		if (class_exists('MetaModel'))
 		{
-			$aTagsToRemove = MetaModel::GetModuleSetting('combodo-email-synchro', 'html-tags-to-remove', $aTagsToRemove);	
+			$aTagsToRemove = MetaModel::GetModuleSetting('combodo-email-synchro', 'html_tags_to_remove', $aTagsToRemove);	
 		}		
 		
 		$this->oDoc = new DOMDocument();
@@ -366,9 +366,9 @@ class EmailMessage {
 
 		if (class_exists('MetaModel'))
 		{
-			$aIntroductoryPatterns = MetaModel::GetModuleSetting('combodo-email-synchro', 'introductory-patterns', $aIntroductoryPatterns);	
-			$aGlobalDelimiterPatterns = MetaModel::GetModuleSetting('combodo-email-synchro', 'multiline-delimiter-patterns', $aGlobalDelimiterPatterns);
-			$aDelimiterPatterns = MetaModel::GetModuleSetting('combodo-email-synchro', 'delimiter-patterns', $aDelimiterPatterns);
+			$aIntroductoryPatterns = MetaModel::GetModuleSetting('combodo-email-synchro', 'introductory_patterns', $aIntroductoryPatterns);	
+			$aGlobalDelimiterPatterns = MetaModel::GetModuleSetting('combodo-email-synchro', 'multiline_delimiter_patterns', $aGlobalDelimiterPatterns);
+			$aDelimiterPatterns = MetaModel::GetModuleSetting('combodo-email-synchro', 'delimiter_patterns', $aDelimiterPatterns);
 		}
 		
 		if ($sBodyFormat == 'text/html')

--- a/module.combodo-email-synchro.php
+++ b/module.combodo-email-synchro.php
@@ -157,7 +157,7 @@ if (!class_exists('EmailSynchroInstaller'))
 				if($aNewSettingValue === null) {
 					
 					$aDeprecatedSettingValue = $oConfiguration->GetModuleSetting('combodo-email-synchro', str_replace('_', '-', $sSetting), null);
-					if($aValue !== null) {
+					if($aDeprecatedSettingValue !== null) {
 						$oConfiguration->SetModuleSetting('combodo-email-synchro', $sSetting, $aDeprecatedSettingValue);
 					}
 			}

--- a/module.combodo-email-synchro.php
+++ b/module.combodo-email-synchro.php
@@ -122,20 +122,8 @@ if (!class_exists('EmailSynchroInstaller'))
 				SetupPage::log_info("Updated $iRet rows.");
 			}
 			
-		}
-		
-		/**
-		 * Handler called before the creation/update of the database schema
-		 *
-		 * @param $oConfiguration Config The new configuration of the application
-		 *
-		 * @returns \Config $oConfiguration The new configuration of the application
-		 *
-		 */
-		public static function BeforeWritingConfig(Config $oConfiguration)
-		{
-			
-			//if($sPreviousVersion != '' && version_compare($sPreviousVersion, '2.6.201218', '<=')) {
+			// Workaround for BeforeWritingConfig() not having $sPreviousVersion
+			if($sPreviousVersion != '' && version_compare($sPreviousVersion, '3.3.1', '<=')) {
 				
 				// In previous versions, these parameters were not named in a consistent way. Rename.
 				$aSettings = array(
@@ -153,13 +141,30 @@ if (!class_exists('EmailSynchroInstaller'))
 					
 					$aDeprecatedSettingValue = $oExistingConfig->GetModuleSetting('combodo-email-synchro', str_replace('_', '-', $sSetting), null);
 					if($aDeprecatedSettingValue !== null) {
-						$oConfiguration->SetModuleSetting('combodo-email-synchro', $sSetting, $aDeprecatedSettingValue);
+						$oExistingConfig->SetModuleSetting('combodo-email-synchro', $sSetting, $aDeprecatedSettingValue);
 					}
 					
 				}
 				
+				// Update existing configuration PRIOR to iTop installation actually processing this.
+				$oExistingConfig->WriteToFile();
+				
+			}
 			
-			//}
+		}
+		
+		/**
+		 * Handler called before the creation/update of the database schema
+		 *
+		 * @param $oConfiguration Config The new configuration of the application
+		 *
+		 * @returns \Config $oConfiguration The new configuration of the application
+		 *
+		 */
+		public static function BeforeWritingConfig(Config $oConfiguration)
+		{
+			
+			return $oConfiguration;
 		}
 
 	}

--- a/module.combodo-email-synchro.php
+++ b/module.combodo-email-synchro.php
@@ -128,43 +128,38 @@ if (!class_exists('EmailSynchroInstaller'))
 		 * Handler called before the creation/update of the database schema
 		 *
 		 * @param $oConfiguration Config The new configuration of the application
-		 * @param $sPreviousVersion string Previous version number of the module (empty string in case of first install)
-		 * @param $sCurrentVersion string Current version number of the module
 		 *
-		 * @throws \ArchivedObjectException
-		 * @throws \CoreException
-		 * @throws \CoreUnexpectedValue
-		 * @throws \DictExceptionMissingString
-		 * @throws \MySQLException
-		 * @throws \MySQLHasGoneAwayException
+		 * @returns \Config $oConfiguration The new configuration of the application
+		 *
 		 */
-		public static function BeforeDatabaseCreation(Config $oConfiguration, $sPreviousVersion, $sCurrentVersion)
+		public static function BeforeWritingConfig(Config $oConfiguration)
 		{
 			
-			// In previous versions, these parameters were not named in a consistent way. Rename.
-			$aSettings = array(
-				'html_tags_to_remove', 
-				'introductory_patterns',
-				'multiline_delimiter_patterns',
-				'delimiter_patterns'
-			);
-			
-			foreach($aSettings as $sSetting)
-			{
+			//if($sPreviousVersion != '' && version_compare($sPreviousVersion, '2.6.201218', '<=')) {
 				
-				$aNewSettingValue = $oConfiguration->GetModuleSetting('combodo-email-synchro', $sSetting, null);
+				// In previous versions, these parameters were not named in a consistent way. Rename.
+				$aSettings = array(
+					'html_tags_to_remove', 
+					'introductory_patterns',
+					'multiline_delimiter_patterns',
+					'delimiter_patterns'
+				);
 				
-				if($aNewSettingValue === null) {
+				$sTargetEnvironment = 'production';
+				$sConfigFile = APPCONF.$sTargetEnvironment.'/'.ITOP_CONFIG_FILE;
+				$oExistingConfig = new Config($sConfigFile);
+				
+				foreach($aSettings as $sSetting) {
 					
-					$aDeprecatedSettingValue = $oConfiguration->GetModuleSetting('combodo-email-synchro', str_replace('_', '-', $sSetting), null);
+					$aDeprecatedSettingValue = $oExistingConfig->GetModuleSetting('combodo-email-synchro', str_replace('_', '-', $sSetting), null);
 					if($aDeprecatedSettingValue !== null) {
 						$oConfiguration->SetModuleSetting('combodo-email-synchro', $sSetting, $aDeprecatedSettingValue);
 					}
-			}
+					
+				}
+				
 			
-			// Necessary?
-			$oConfiguration->WriteToFile();
-			
+			//}
 		}
 
 	}


### PR DESCRIPTION
Not sure if I should finish this (probably just needs testing, perhaps remove the explicit config saving instruction).

* removes a redundant line with a typo
* renames the settings to only use underscores (+ handling of existing settings in the configuration file: rewrite. Any native method to delete the old settings?)
* also, some settings were not in the module's config file. While this is not necessary, it makes it clearer to users what the possible settings are. Furthermore; it seems like some of the settings were slightly different between the demo configuration and the default-if-not-specified settings in the code.

The upgrade check could also be based on version number of the extension instead.
Actually for now it does NOT work, it seems configuration is based on what is specified "by default".
I was looking into **BeforeWritingConfig**, which doesn't support previous and current version. (perhaps this could be added?)
But for some reason, it also doesn't include the existing configuration yet?
