### PR TITLE
🐛 N°4170 - Fix encoding issue for long subjects (and other MIME UTF8 encoded data on multiple lines)

### DIFF
--- a/classes/rawemailmessage.class.inc.php
+++ b/classes/rawemailmessage.class.inc.php
@@ -614,6 +614,7 @@ class RawEmailMessage
 	{
 		// Fix an encoding issue which may occur in multiline headers if it is indeed a utf-8 encoded string.
 		// Check if the string starts with =?utf-8? (sometimes with space in front) and ends with ?=
+		// This could happen also for other charsets but we weren't able to reproduce the same problem with another charset => so we're keeping UTF-8 hardcoded for now !
 		if(preg_match('/^(\s|){1,}=\?utf-8\?(.*)\?=/', $sInput)) {
 			// Remove leading white space
 			$sInput = preg_replace('/^(\s)/', '', $sInput);

--- a/classes/rawemailmessage.class.inc.php
+++ b/classes/rawemailmessage.class.inc.php
@@ -606,6 +606,17 @@ class RawEmailMessage
 	 */
 	static protected function DecodeHeaderString($sInput)
 	{
+		// Fix an encoding issue which may occur in multiline headers if it is indeed a utf-8 encoded string.
+		// Check if the string starts with =?utf-8? (sometimes with space in front) and ends with ?=
+		if(preg_match('/^(\s|){1,}=\?utf-8\?(.*)\?=/', $sInput)) {
+			// Remove leading white space
+			$sInput = preg_replace('/^(\s)/', '', $sInput);
+			// Remove any space of UTF8 seperation in the lines which were merged in the ExtractHeadersAndRawBody() method
+			// Mind that it's possible that some lines of a multiline subject have different encodings! (utf-8-b; utf-8-q; ...)
+			// Examples: ?==?utf-8? , ?= =?utf-8?
+			$sInput = preg_replace('/\?=(\s|){1,}=\?utf-8\?/', '?==?utf-8?', $sInput);			
+		}
+		
 		$sOutput = iconv_mime_decode($sInput, ICONV_MIME_DECODE_CONTINUE_ON_ERROR, 'UTF-8');
 		return $sOutput; // Don't be too strict, continue on errors
 	}

--- a/test/TestEmlFiles.php
+++ b/test/TestEmlFiles.php
@@ -143,7 +143,7 @@ class TestEmlFiles extends ItopTestCase
 
 		$oEmail = RawEmailMessage::FromFile($sEmlFilePath);
 		$sSubjectActualValue = $oEmail->GetSubject();
-		$this->assertSame($sSubjectExpectedValue, $sSubjectActualValue, 'Decoded subject has a wrong value');
+		$this->assertSame($sSubjectExpectedValue, $sSubjectActualValue, "File `{$sEmailFilename}` : decoded subject has a wrong value");
 	}
 
 	public function MultilineLongSubjectsProvider(): array
@@ -151,10 +151,10 @@ class TestEmlFiles extends ItopTestCase
 		return [
 			['multi_lines_header_parsing.eml', 'Re: autonet backup: nanobeam-ma15-sec-kunde.mgmt (1047) [Space.NET R-201909190397]'],
 			['email_133_kb4170_multiple_lines_encoded_data.eml', 'FW: ⚠ This is a test with an emoji in the subject and a long subject message which will cause multi line subjects and encoding'],
-			//			['email_065.eml', ''],//FIXME
-			//			['email_077.eml', ''],//FIXME
-			//			['email_107.eml', ''],//FIXME
-			//			['test gmail.eml', ''],//FIXME
+			['email_065.eml', 'Re: iTop - Enhancement request - Classes et héritage'],
+			['email_077.eml', 'Vente Flash Otto Office ! Spécial High-Tech, attention stocks limités !'],
+			['email_107.eml', 'Fwd: Suite entretien téléphonique de ce jour'],
+			['test gmail.eml', 'Test de mail envoyé avec Gmail et contenant un très très long sujet avec d\'aillleurs aussi des caractères accentués histoire de voir ce qui se passe dans ce cas là. Je sais c\'est un peu exagéré, enfin à peine...'],
 		];
 	}
 }

--- a/test/TestEmlFiles.php
+++ b/test/TestEmlFiles.php
@@ -37,8 +37,13 @@ class TestEmlFiles extends ItopTestCase
 		$sSubject = $oEmail->GetSubject();
 		$this->assertNotEmpty($sSubject);
 		//
-		if (str_replace(APPROOT . 'env-production/combodo-email-synchro/test/emailsSample/','',$sFileName) == "multi_lines_header_parsing.eml"){
-			$this->assertEquals( 'Re: autonet backup: nanobeam-ma15-sec-kunde.mgmt (1047) [Space.NET R-201909190397]',$sSubject);
+		switch(str_replace(APPROOT . 'env-production/combodo-email-synchro/test/emailsSample/', '', $sFileName)) {
+			case 'multi_lines_header_parsing.eml':
+				$this->assertEquals('Re: autonet backup: nanobeam-ma15-sec-kunde.mgmt (1047) [Space.NET R-201909190397]', $sSubject);
+				break;
+			case 'email_133_kb4170_multiple_lines_encoded_data.eml':
+				$this->assertEquals('FW: ⚠ This is a test with an emoji in the subject and a long subject message which will cause multi line subjects and encoding', $sSubject);
+				break;
 		}
 
 		$aSender = $oEmail->GetSender();

--- a/test/emailsSample/email_133_kb4170_multiple_lines_encoded_data.eml
+++ b/test/emailsSample/email_133_kb4170_multiple_lines_encoded_data.eml
@@ -1,0 +1,194 @@
+Received: from DB3PR0202MB3497.eurprd02.prod.outlook.com (2603:10a6:8:5::27)
+ by AM9PR02MB6595.eurprd02.prod.outlook.com with HTTPS; Sat, 17 Jul 2021
+ 08:50:16 +0000
+Received: from DBBPR09CA0036.eurprd09.prod.outlook.com (2603:10a6:10:d4::24)
+ by DB3PR0202MB3497.eurprd02.prod.outlook.com (2603:10a6:8:5::27) with
+ Microsoft SMTP Server (version=TLS1_2,
+ cipher=TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384) id 15.20.4331.26; Sat, 17 Jul
+ 2021 08:50:15 +0000
+Received: from DB5EUR03FT053.eop-EUR03.prod.protection.outlook.com
+ (2603:10a6:10:d4:cafe::cb) by DBBPR09CA0036.outlook.office365.com
+ (2603:10a6:10:d4::24) with Microsoft SMTP Server (version=TLS1_2,
+ cipher=TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384) id 15.20.4331.21 via Frontend
+ Transport; Sat, 17 Jul 2021 08:50:15 +0000
+Received: from EUR03-VE1-obe.outbound.protection.outlook.com (40.92.72.92) by
+ DB5EUR03FT053.mail.protection.outlook.com (10.152.21.119) with Microsoft SMTP
+ Server (version=TLS1_2, cipher=TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384) id
+ 15.20.4331.21 via Frontend Transport; Sat, 17 Jul 2021 08:50:15 +0000
+Received: from AM9PR02MB6595.eurprd02.prod.outlook.com (2603:10a6:20b:2c8::23)
+ by AM9PR02MB6753.eurprd02.prod.outlook.com (2603:10a6:20b:2c6::14) with
+ Microsoft SMTP Server (version=TLS1_2,
+ cipher=TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384) id 15.20.4331.23; Sat, 17 Jul
+ 2021 08:50:15 +0000
+Received: from AM9PR02MB6595.eurprd02.prod.outlook.com
+ ([fe80::aca0:a91f:91e5:6368]) by AM9PR02MB6595.eurprd02.prod.outlook.com
+ ([fe80::aca0:a91f:91e5:6368%4]) with mapi id 15.20.4331.021; Sat, 17 Jul 2021
+ 08:50:15 +0000
+From: Jeffrey Bostoen <jbostoen@censored.com>
+To: Jeffrey Bostoen <jbostoen@censored.com>
+Subject:
+	=?utf-8?B?Rlc6IOKaoCBUaGlzIGlzIGEgdGVzdCB3aXRoIGFuIGVtb2ppIGluIHRoZSBz?=
+ =?utf-8?B?dWJqZWN0IGFuZCBhIGxvbmcgc3ViamVjdCBtZXNzYWdlIHdoaWNoIHdpbGwg?=
+ =?utf-8?Q?cause_multi_line_subjects_and_encoding?=
+Thread-Topic:
+	=?utf-8?B?4pqgIFRoaXMgaXMgYSB0ZXN0IHdpdGggYW4gZW1vamkgaW4gdGhlIHN1Ympl?=
+ =?utf-8?B?Y3QgYW5kIGEgbG9uZyBzdWJqZWN0IG1lc3NhZ2Ugd2hpY2ggd2lsbCBjYXVz?=
+ =?utf-8?Q?e_multi_line_subjects_and_encoding?=
+Thread-Index: Add66Lz27pXF+0kbR2eqDdtHTwhijQ==
+X-MS-Exchange-MessageSentRepresentingType: 1
+Date: Sat, 17 Jul 2021 08:50:15 +0000
+Message-ID:
+	<AM9PR02MB6595D89D8644FDF29ECF88CAD8109@AM9PR02MB6595.eurprd02.prod.outlook.com>
+Accept-Language: en-US
+Content-Language: en-US
+X-MS-Exchange-Organization-AuthAs: Anonymous
+X-MS-Exchange-Organization-AuthSource:
+	DB5EUR03FT053.eop-EUR03.prod.protection.outlook.com
+X-MS-Has-Attach:
+X-MS-Exchange-Organization-Network-Message-Id:
+	4be8244d-5fbc-4542-d46b-08d948ffe5cb
+X-MS-Exchange-Organization-SCL: -1
+X-MS-Exchange-Organization-PCL: 2
+X-MS-TNEF-Correlator:
+X-MS-Exchange-Organization-RecordReviewCfmType: 0
+received-spf: Pass (protection.outlook.com: domain of outlook.com designates
+ 40.92.72.92 as permitted sender) receiver=protection.outlook.com;
+ client-ip=40.92.72.92; helo=EUR03-VE1-obe.outbound.protection.outlook.com;
+x-ms-publictraffictype: Email
+authentication-results: spf=pass (sender IP is 40.92.72.92)
+ smtp.mailfrom=outlook.com; outlook.com; dkim=pass (signature was verified)
+ header.d=outlook.com;outlook.com; dmarc=pass action=none
+ header.from=outlook.com;compauth=pass reason=100
+x-ms-traffictypediagnostic: AM9PR02MB6753:|DB3PR0202MB3497:
+x-ms-office365-filtering-correlation-id: 4be8244d-5fbc-4542-d46b-08d948ffe5cb
+x-microsoft-antispam: BCL:0;
+dkim-signature: v=1; a=rsa-sha256; c=relaxed/relaxed; d=outlook.com;
+ s=selector1;
+ h=From:Date:Subject:Message-ID:Content-Type:MIME-Version:X-MS-Exchange-SenderADCheck;
+ bh=mspojGaONsq902WbV1dQkLi61Jr9QSSvKY60AaXuLTo=;
+ b=i4c8oK+yTOVtEN8JBkwonO6Jz1zNi2lCWd/55AtNM16kJ+Wa8bYInJsQXkKrlKT1q/qouXvJ32G2l18SRHncA9doCACzodaa7MXcJM/sospSjsCv+aJY31GlEdoCot+8FXqnzhlJKmellrWSEen6e17zUosE8tsx+XpOZGsmgsnWNqQM+DbvKyMg/qguEnsYdVGHgbVXD4LaS8rxwePP9AdZotA6CkeRIt24wb8xHbsxu4FGpAeXVVmJ6+APHHP0p4c4gy3Wm8I/CEP8mhaJuSCBSYXjYlx/h7AfT4/58ZH00rCFgq8bJnLOosjLqC5BubgkARt+6nR6Kii3ER11pg==
+arc-seal: i=1; a=rsa-sha256; s=arcselector9901; d=microsoft.com; cv=none;
+ b=QZGy2tiY7WJYbcXjdlB7F2qBV9CZ+zJdBnZzj3qyL4mHbLWnZF7cpwj1y4P4TfNKDYoOMLzNwKyPJat1pWp53hTvtu+yNB3kNuu3Jfe0eT9fUuFSWRUjdn+v7sdVGFfWsDOFhWNLV3kEkd8iqa2fAS6gp4QBoCce3CTsg/L/zL5x/jNPg9xDwQ5687idhlBXhFBMTijv4PwFLEtQWmAcr0+b02BgMdohLLuEIRTnvI8C/PE1Bab0B1oHIuXevpsd9EDka/KsJ9EsaTxVblfrNzBwefYSgMi8+SLL57IBZoaKmFHunhGyv/8BdIApRPEs3RIfK2NUi0azNN2xDSQCVg==
+arc-message-signature: i=1; a=rsa-sha256; c=relaxed/relaxed; d=microsoft.com;
+ s=arcselector9901;
+ h=From:Date:Subject:Message-ID:Content-Type:MIME-Version:X-MS-Exchange-SenderADCheck;
+ bh=mspojGaONsq902WbV1dQkLi61Jr9QSSvKY60AaXuLTo=;
+ b=lyH2zb57kZNoayfxaaDltoCBfblTMtLjDlVFMTSH+YPzELLSCyCWF8IM+3kcAArcRka/JVE5xmzkpe5gRfiaiTMqqfQ01zPKSwqmR/CaNS/AP/xW/M29Bqt9zEFvKMc7afmHdKrrwyUrzc6/CMSbD66kdi8ld4uYC4DtYWBt0fDI8FzZLOqmmgoxEzrQokm9+hgL8m8+tqAjnKxqbr33FZBdEmHwYW1HDHcM5f/chaqDopKTjeLd0KirYAX4zRPJuIoqrc73qLPtLInlB7K/j2SXeW8d72aIr/TBaildM1rGgdTrQRVlWu8G1EsI4G+i00fPNMmCEEsBPpeBvHr5Sg==
+arc-authentication-results: i=1; mx.microsoft.com 1; spf=none; dmarc=none;
+ dkim=none; arc=none
+x-incomingtopheadermarker:
+	OriginalChecksum:A96AD7D2022476EF961C4282BE21E36BEA2BD06C46E27FFBC59610BA4A9B1B0C;UpperCasedChecksum:283449498150FF2E4E1E7B15F9DD0162FB1D71220C11312CECA6811C4C237384;SizeAsReceived:5742;Count:39
+x-tmn:
+	[OMEt7oPA69SRnbkhgllIM0tC3985XvwqKrKLRR1r0+hZNnsyRXLazITMUzhOcNbtg7Drft9omUQ=]
+x-incomingheadercount: 39
+x-eopattributedmessage: 0
+x-microsoft-antispam-message-info:
+	qanjKyCfCofkS5dtt6yFCfQLLfPUntrA1RgtL6hl07681qUWanZmjp4LuN4DQWwfEpJ1b7Ki0+yLxzFoTH6eIBbjGylrN2r1p9TrWnaWaeBgi15ihsdf+E9FKuLaDy7FV9zQUJ/oECk4hGaqjlmywFurN1/v8IO+hA9+Enf/VhT8pjIHl52WwMUri6vc2iBevME6CAwpCKAfJAlKJdf/jxwvfTwub6fqM3STHFR5mY8F3SiBywv3BPoZ/Ro72RWojMrgIW7Ri7HHP1YhsNK+nLO90SSxoE8uwBLz4znyJF7nGgKSnkg3Ct0TU0Rsq0Ezkau6B8rBADETgQtwjYuJYErUpUETlzznepEVGxtur1sf9FojL6zslayFVK7GoyWWHp67QxRVnzxoJL1L7kz9fYjb/71K8yU0imz8uS3GW0N/WggW+c+Izxor1upNwvES
+x-ms-exchange-transport-forked: True
+x-ms-exchange-crosstenant-rms-persistedconsumerorg:
+	00000000-0000-0000-0000-000000000000
+x-ms-exchange-crosstenant-network-message-id:
+	4be8244d-5fbc-4542-d46b-08d948ffe5cb
+x-ms-exchange-crosstenant-originalarrivaltime: 17 Jul 2021 08:50:15.8033 (UTC)
+x-ms-exchange-crosstenant-fromentityheader: Internet
+x-ms-exchange-crosstenant-id: 84df9e7f-e9f6-40af-b435-aaaaaaaaaaaa
+x-ms-exchange-transport-crosstenantheadersstamped: DB3PR0202MB3497
+x-microsoft-antispam-untrusted: BCL:0;
+x-microsoft-antispam-message-info-original:
+	qanjKyCfCofkS5dtt6yFCfQLLfPUntrA1RgtL6hl07681qUWanZmjp4LuN4DQWwfEpJ1b7Ki0+yLxzFoTH6eIBbjGylrN2r1p9TrWnaWaeBgi15ihsdf+E9FKuLaDy7FV9zQUJ/oECk4hGaqjlmywFurN1/v8IO+hA9+Enf/VhT8pjIHl52WwMUri6vc2iBevME6CAwpCKAfJAlKJdf/jxwvfTwub6fqM3STHFR5mY8F3SiBywv3BPoZ/Ro72RWojMrgIW7Ri7HHP1YhsNK+nLO90SSxoE8uwBLz4znyJF7nGgKSnkg3Ct0TU0Rsq0Ezkau6B8rBADETgQtwjYuJYErUpUETlzznepEVGxtur1sf9FojL6zslayFVK7GoyWWHp67QxRVnzxoJL1L7kz9fYjb/71K8yU0imz8uS3GW0N/WggW+c+Izxor1upNwvES
+x-eoptenantattributedmessage: 84df9e7f-e9f6-40af-b435-aaaaaaaaaaaa:0
+x-ms-exchange-transport-crosstenantheadersstripped:
+	DB5EUR03FT053.eop-EUR03.prod.protection.outlook.com
+x-ms-exchange-transport-crosstenantheaderspromoted:
+	DB5EUR03FT053.eop-EUR03.prod.protection.outlook.com
+x-ms-office365-filtering-correlation-id-prvs:
+	c8cc0d18-4814-4f4e-6695-08d948ffe55f
+x-ms-exchange-crosstenant-authsource:
+	DB5EUR03FT053.eop-EUR03.prod.protection.outlook.com
+x-ms-exchange-crosstenant-authas: Anonymous
+x-ms-exchange-slblob-mailprops:
+	79Jo46q8hhDyTo9P99hRQAQ3TG/q6CYJf2dXUHgPxhw5xFlpSmqJC8wUeSrekrU8DDIi3vzhSqXfeINCEzIM6uLn8G1c0L34Q6fAuTRwufNl6eq7FX2JxXAu5dwXTGDBCq6YVzLJU49nwMsarBnBK544bmPfWTwYZvQYKll5d5+SkUtp2IG4O+kp9apkPS2FpXfzuNXqordYzucgThu8AhlD8mfSdrCo+4Fl9sTTqzLnwtWbGTfP3JRsHRXjTN1rGUEQvUFkQup1a01Oee0fGvIxuDOkua4k+wIFI9cfPQHkxmWv+4CRUv/MD23lWRPzYJvldH1UczWlAf9lZ+IyW0p8ozoZ8LEaG8McRSMqzlA/0T/OJqJpNpReFgKCZCUsJXYUWGVAURuHCqVKyYnmQEMoHmAcjnWG+2JHRrNkpVSGrB5vAffGQz/GFBk/XahlqzOH4Nv/cFQvikhqIgGeebD3jDocphMmdm35gK6DM6apvvOqAKk5Bm0P1wtoApOvo+4kUTW+AznV+sTX7pFsn0rLt/BMEzLKedljqawkg3StPPhq9HwMF9l9kPMlMt4Kg5rO3c01gSEvA4YLRtFS16OqLFo2O3xdfLq7feEUZuwb7JWfqsXBPshJwecJH0ZmQlH/2jSSwOOMuzAzxUJfujF9c1wY7At+P/o3oOQ485A2H/nApQteD6fuqx8/Yg1S
+x-ms-exchange-transport-endtoendlatency: 00:00:00.6262636
+x-ms-exchange-processed-by-bccfoldering: 15.20.4331.021
+x-ms-exchange-antispam-messagedata-chunkcount: 1
+x-ms-exchange-antispam-messagedata-0:
+	pJtUE+mtq1sTHMEFg0TYjuiYhAxLcsifIYf1DfRjvESscVRBijtQnb5V+MN+rRl69EO+xP5QRwLB0CmVt6xugOLTjCyBvQpMgN8iF4giPCjYtxQ3sa7zGWVL0dPI3GWDyQzaP6I0dB1AZGEWkjlfQI4c83EqKphtfy20SEjC1s1+zpDnfXJeu2BVBSyguiGaPiPYtqLe6F50wegrNYFN1Q==
+X-Microsoft-Antispam-Mailbox-Delivery:
+	dkl:0;rwl:0;ucf:0;jmr:0;ex:0;auth:1;dest:I;OFR:SpamFilterPass;ENG:(5062000282)(90000117)(90011020)(91015020)(91040095)(91045095)(9050020)(9060116)(9100314)(5061607266)(5061608174)(1004385)(4900115)(2008001114)(2008000189)(4920090)(6220004)(4950131)(4990090)(9110004);
+X-Message-Info:
+	5vMbyqxGkde5GadX+p2DKVRC3kqp4YEKtp6xwUwTfx2EBD4z0gVgwEJnEqnROXg9dqSxmrjAVFySW9dYMXxyta/ta8og7xGFmMwdx2+feSgPJ3v44XMRsBF1EOVfJjSiq5PaML3nnQz1WjI1bAvAj00oNtVmfDokGAWzuyaB2Muy3alrxMFLFY7fo39L9mRLsGu+qOZzJDw8YCB+05PxQw==
+X-Message-Delivery: Vj0xLjE7dXM9MDtsPTA7YT0xO0Q9MTtHRD0xO1NDTD0tMQ==
+X-Microsoft-Antispam-Message-Info:
+	=?utf-8?B?bStoU1RIcVpiQU9SaVUxRFBuZDJvVDAreDBFalR3ditiVnJSTzFKemhUMEJx?=
+ =?utf-8?B?WWdoSko3UTJheVdhVmlYUk1rd1NSM3VlbWlrNWNGK0VyZHJCckIxVThRc0c2?=
+ =?utf-8?B?Z1BzUmphWG1IaTFIbk9vT0VvcWVPNGlCdStwSUJaeVhpTmpJbEt2RVRFbXhJ?=
+ =?utf-8?B?SFVhOFpUdllqSlFQWUZLbS9QemR5YlFKKytobmQ2ZXArRmhlbU80dHJGeDBE?=
+ =?utf-8?B?U0tpckRqd3N6TzJmWmZnZUU2WGVaOEk2R1ZSYmFWZ1NsYitvL0tJMkI4c2Rs?=
+ =?utf-8?B?NVV2bS9uTXhoSjE0RGo1dVB3cXFkVmZuMks3NVd1Q2FXOUc5alkzSitkdzhq?=
+ =?utf-8?B?YkVocVVvcndoK1RLTk9CODJPZHBmditXdjBMMnRDRnFZelk0a3ErV3NwbVFJ?=
+ =?utf-8?B?dGJkeVJBU2hHKzFRcUE3L2VjSlhBSVA5TVI5SS9QeDhtVk1EOHRxWGVMTzJo?=
+ =?utf-8?B?bStkZWRyYjhZNXFKM2x2ZThaemdCZTh6bjRuN0JTNzhDcm5SeFJ2QzVTZVVB?=
+ =?utf-8?B?anRkNmZjUXY1cm1RZTRCSndka3J0Y0pvK3RTeVlJakdiV3dSTzBtRVVWZ0xQ?=
+ =?utf-8?B?ay9lVlBMbU8vdjArcDlTaHcvc2RFUDYycEI2Z2NCa0R1ZDA0ZFk1RldRUGpC?=
+ =?utf-8?B?d3lidUVXUmpnajNneVBEUjNSZFh5MktKenBWUldOS3M2VHFtM1FmRG5kYUwr?=
+ =?utf-8?B?bWY2TnVPTExsS3VrZGI0Rmt1b3hQRHJ0ZVJjRWQ3OTBYZDN2akN5dm1EdVRr?=
+ =?utf-8?B?QXZ6SmR3OGhrMGFwRlpuRCt1TGhJS0IxZjB4MHJtMzFsbUdLRDQraEEyNFUz?=
+ =?utf-8?B?TXJsRm5EeVc4dGtOT0pPWEYvTSttMm1VM01RUjNKYytXY0NhZy9GZHd4N0d0?=
+ =?utf-8?B?Yy9yZUttV2wwK1NzcXF2cGpPa0FXSlZqOFVVSlE4TDRZeEx5QURhOHZJa3Z2?=
+ =?utf-8?B?WjIwZi9FZk5XQ1pjOWFOZUVJdjVBTWh4MFhxWWg5enVWQzV3MkIzTE1YOWUw?=
+ =?utf-8?B?blZBcW4xY0M5QjJLTEdYNUg3MGFPMWFYTmdMdUp4MlhmYVhsQmhvYU9HMUZo?=
+ =?utf-8?B?bllBRFBSODlIa2RYSG9hdy9PNTlIZ0kyOThXNEczZE9GdXprSENaZEJHUEkr?=
+ =?utf-8?B?YlJUQTJHOW5LeWd5b3JrR3UwOEdVQ0oxMHlNOHVMTFRPblhyVEp1UHpxNTZT?=
+ =?utf-8?B?SEh0dFFKTmhUVmpwa1ZvV1dRcmFlV0pVb1hZMnB5enNwd01udXB6N1pEcG1t?=
+ =?utf-8?B?R2NUaVVsVDhoNnhYY0wyU1p0WTh2Zm8rU0hKOGp1S0pqcVdpcDBCMEc3NHY0?=
+ =?utf-8?B?VnJ5VDRidGJlSEgzRjhIaVRVR0RVZVIwVXhhMlYwVmVkS3VjUklVWG1yR2pm?=
+ =?utf-8?B?T2lwR2Z3NERwK3pFYk1Nek5SUkZydmNMcmJDUlZFLzBlNkdnNTVhelNDeHh3?=
+ =?utf-8?B?SEhmR2xJbXEwRTVCN21NNTVEZzlhR3oxTVczOTRnPT0=?=
+Content-Type: multipart/alternative;
+	boundary="_000_AM9PR02MB6595D89D8644FDF29ECF88CAD8109AM9PR02MB6595eurp_"
+MIME-Version: 1.0
+
+--_000_AM9PR02MB6595D89D8644FDF29ECF88CAD8109AM9PR02MB6595eurp_
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: base64
+
+DQoNCktpbmQgcmVnYXJkcw0KTWV0IHZyaWVuZGVsaWprZSBncm9ldGVuDQoNCkplZmZyZXkgQm9z
+dG9lbg0KDQo=
+
+--_000_AM9PR02MB6595D89D8644FDF29ECF88CAD8109AM9PR02MB6595eurp_
+Content-Type: text/html; charset="utf-8"
+Content-Transfer-Encoding: base64
+
+PGh0bWw+DQo8aGVhZD4NCjxtZXRhIGh0dHAtZXF1aXY9IkNvbnRlbnQtVHlwZSIgY29udGVudD0i
+dGV4dC9odG1sOyBjaGFyc2V0PXV0Zi04Ij4NCjxtZXRhIG5hbWU9IkdlbmVyYXRvciIgY29udGVu
+dD0iTWljcm9zb2Z0IFdvcmQgMTUgKGZpbHRlcmVkIG1lZGl1bSkiPg0KPHN0eWxlPjwhLS0NCi8q
+IEZvbnQgRGVmaW5pdGlvbnMgKi8NCkBmb250LWZhY2UNCgl7Zm9udC1mYW1pbHk6IkNhbWJyaWEg
+TWF0aCI7DQoJcGFub3NlLTE6MiA0IDUgMyA1IDQgNiAzIDIgNDt9DQpAZm9udC1mYWNlDQoJe2Zv
+bnQtZmFtaWx5OkNhbGlicmk7DQoJcGFub3NlLTE6MiAxNSA1IDIgMiAyIDQgMyAyIDQ7fQ0KLyog
+U3R5bGUgRGVmaW5pdGlvbnMgKi8NCnAuTXNvTm9ybWFsLCBsaS5Nc29Ob3JtYWwsIGRpdi5Nc29O
+b3JtYWwNCgl7bWFyZ2luOjBjbTsNCglmb250LXNpemU6MTEuMHB0Ow0KCWZvbnQtZmFtaWx5OiJD
+YWxpYnJpIixzYW5zLXNlcmlmOw0KCW1zby1mYXJlYXN0LWxhbmd1YWdlOkVOLVVTO30NCnNwYW4u
+RW1haWxTdHlsZTE3DQoJe21zby1zdHlsZS10eXBlOnBlcnNvbmFsLWNvbXBvc2U7DQoJZm9udC1m
+YW1pbHk6IkNhbGlicmkiLHNhbnMtc2VyaWY7DQoJY29sb3I6d2luZG93dGV4dDt9DQouTXNvQ2hw
+RGVmYXVsdA0KCXttc28tc3R5bGUtdHlwZTpleHBvcnQtb25seTsNCglmb250LWZhbWlseToiQ2Fs
+aWJyaSIsc2Fucy1zZXJpZjsNCgltc28tZmFyZWFzdC1sYW5ndWFnZTpFTi1VUzt9DQpAcGFnZSBX
+b3JkU2VjdGlvbjENCgl7c2l6ZTo2MTIuMHB0IDc5Mi4wcHQ7DQoJbWFyZ2luOjcyLjBwdCA3Mi4w
+cHQgNzIuMHB0IDcyLjBwdDt9DQpkaXYuV29yZFNlY3Rpb24xDQoJe3BhZ2U6V29yZFNlY3Rpb24x
+O30NCi0tPjwvc3R5bGU+PCEtLVtpZiBndGUgbXNvIDldPjx4bWw+DQo8bzpzaGFwZWRlZmF1bHRz
+IHY6ZXh0PSJlZGl0IiBzcGlkbWF4PSIxMDI2IiAvPg0KPC94bWw+PCFbZW5kaWZdLS0+PCEtLVtp
+ZiBndGUgbXNvIDldPjx4bWw+DQo8bzpzaGFwZWxheW91dCB2OmV4dD0iZWRpdCI+DQo8bzppZG1h
+cCB2OmV4dD0iZWRpdCIgZGF0YT0iMSIgLz4NCjwvbzpzaGFwZWxheW91dD48L3htbD48IVtlbmRp
+Zl0tLT4NCjwvaGVhZD4NCjxib2R5IGxhbmc9ImVuLUJFIiBsaW5rPSIjMDU2M0MxIiB2bGluaz0i
+Izk1NEY3MiIgc3R5bGU9IndvcmQtd3JhcDpicmVhay13b3JkIj4NCjxkaXYgY2xhc3M9IldvcmRT
+ZWN0aW9uMSI+DQo8cCBjbGFzcz0iTXNvTm9ybWFsIj48c3BhbiBsYW5nPSJlbi1CRSI+PG86cD4m
+bmJzcDs8L286cD48L3NwYW4+PC9wPg0KPHAgY2xhc3M9Ik1zb05vcm1hbCI+PHNwYW4gbGFuZz0i
+ZW4tQkUiPjxvOnA+Jm5ic3A7PC9vOnA+PC9zcGFuPjwvcD4NCjxwIGNsYXNzPSJNc29Ob3JtYWwi
+PjxzcGFuIGxhbmc9Ik5MLUJFIiBzdHlsZT0iY29sb3I6YmxhY2siPktpbmQgcmVnYXJkczxvOnA+
+PC9vOnA+PC9zcGFuPjwvcD4NCjxwIGNsYXNzPSJNc29Ob3JtYWwiPjxzcGFuIGxhbmc9Ik5MLUJF
+IiBzdHlsZT0iY29sb3I6YmxhY2siPk1ldCB2cmllbmRlbGlqa2UgZ3JvZXRlbjxicj4NCjxicj4N
+CkplZmZyZXkgQm9zdG9lbjwvc3Bhbj48c3BhbiBsYW5nPSJOTC1CRSIgc3R5bGU9ImNvbG9yOmJs
+YWNrO21zby1mYXJlYXN0LWxhbmd1YWdlOiMyMDAwIj48bzpwPjwvbzpwPjwvc3Bhbj48L3A+DQo8
+cCBjbGFzcz0iTXNvTm9ybWFsIj48c3BhbiBsYW5nPSJlbi1CRSI+PG86cD4mbmJzcDs8L286cD48
+L3NwYW4+PC9wPg0KPC9kaXY+DQo8L2JvZHk+DQo8L2h0bWw+DQo=
+
+--_000_AM9PR02MB6595D89D8644FDF29ECF88CAD8109AM9PR02MB6595eurp_--

--- a/test/emailsSample/readme.txt
+++ b/test/emailsSample/readme.txt
@@ -1,2 +1,3 @@
 email_131.eml: Email with "us-ascii" charset and binary attachment. (Issue was that attachment was converted through iconv() when it should not)
 email_132.eml: Email with uppercase content-transfer-encoding ("BASE64"). (Issue was that mail had "Quote-Printable" and "BASE64" instead of lowercase ones)
+email_133.eml: Email with a multiline subject with different MIME encodings (Issue that caused white space in front of subject)

--- a/test/emailsSample/readme.txt
+++ b/test/emailsSample/readme.txt
@@ -1,3 +1,3 @@
 email_131.eml: Email with "us-ascii" charset and binary attachment. (Issue was that attachment was converted through iconv() when it should not)
 email_132.eml: Email with uppercase content-transfer-encoding ("BASE64"). (Issue was that mail had "Quote-Printable" and "BASE64" instead of lowercase ones)
-email_133.eml: Email with a multiline subject with different MIME encodings (Issue that caused white space in front of subject)
+email_133_kb4170_multiple_lines_encoded_data.eml: Email with a multiline subject with different MIME encodings (Issue that caused white space in front of subject)


### PR DESCRIPTION
Subject headers which were on multiple lines (and perhaps other headers too) suffer from a MIME decoding issue, causing whitespace or tabs to be added.

Below are two examples of subjects and how Outlook encoded the header.

FW: ⚠ This is a test with an emoji in the subject and a long subject message which will cause multi line subjects and encoding
```
Subject:
 =?utf-8?B?Rlc6IOKaoCBUaGlzIGlzIGEgdGVzdCB3aXRoIGFuIGVtb2ppIGluIHRoZSBz?=
 =?utf-8?B?dWJqZWN0IGFuZCBhIGxvbmcgc3ViamVjdCBtZXNzYWdlIHdoaWNoIHdpbGwg?=
 =?utf-8?Q?cause_multi_line_subjects_and_encoding?=
```

FW: ⚠ Aanpassing: 'verwijderde items' in Outlook zal na 90 dagen automatisch gewist worden

```
Subject:
 =?utf-8?B?Rlc6IOKaoCBBYW5wYXNzaW5nOiAndmVyd2lqZGVyZGUgaXRlbXMnIGluIE91?=
 =?utf-8?Q?tlook_zal_na_90_dagen_automatisch_gewist_worden?=
```

Debugging (logging the input and output of the DecodeHeaderString() method):
```
input: 	=?utf-8?B?Rlc6IOKaoCBUaGlzIGlzIGEgdGVzdCB3aXRoIGFuIGVtb2ppIGluIHRoZSBz?= =?utf-8?B?dWJqZWN0IGFuZCBhIGxvbmcgc3ViamVjdCBtZXNzYWdlIHdoaWNoIHdpbGwg?= =?utf-8?Q?cause_multi_line_subjects_and_encoding?=
output: 	FW: ⚠ This is a test with an emoji in the subject and a long subject message which will cause multi line subjects and encoding
input: =?utf-8?B?4pqgIFRoaXMgaXMgYSB0ZXN0IHdpdGggYW4gZW1vamkgaW4gdGhlIHN1Ympl?==?utf-8?B?Y3QgYW5kIGEgbG9uZyBzdWJqZWN0IG1lc3NhZ2Ugd2hpY2ggd2lsbCBjYXVz?==?utf-8?Q?e_multi_line_subjects_and_encoding?=
output: ⚠ This is a test with an emoji in the subject and a long subject message which will cause multi line subjects and encoding
```
This patch solves the MIME decoding by checking if there's still redundant leading white space (space, tab) before encoded strings. It also removes space in between encoded strings to be on the safe side.