### PR TITLE
N°9872 - Check whether a message is an auto reply based on configuration

### DIFF
--- a/classes/emailmessage.class.inc.php
+++ b/classes/emailmessage.class.inc.php
@@ -462,4 +462,34 @@ class EmailMessage {
 		}
 		return null;
 	}
+
+	/**
+	 * Check whether the message is an auto reply
+	 * @return bool
+	 * @since 3.5.1
+	 */
+	public function IsAutoReplyEmail()
+	{
+		$aAutoReplyHeaderPatterns = array(
+			'auto-submitted' => '/^auto-replied.*$/i',
+		);
+		if (class_exists('MetaModel'))
+		{
+			$aAutoReplyHeaderPatterns = MetaModel::GetModuleSetting('combodo-email-synchro', 'auto_reply_header_patterns', $aAutoReplyHeaderPatterns);
+		}	
+		foreach ($aAutoReplyHeaderPatterns as $sHeader => $sPattern) {
+			if(array_key_exists(strtolower($sHeader), $this->aHeaders))
+			{
+				IssueLog::Debug("Header \"$sHeader\" exists with the value: \"" . $this->aHeaders[strtolower($sHeader)] . "\"");
+				if (preg_match($sPattern, $this->aHeaders[strtolower($sHeader)]))
+				{
+					// Current mail is an auto reply
+					IssueLog::Debug("Given mail is an autoreply!");
+					return true;
+				}	
+			}
+		}
+
+		return false;
+	}
 }

--- a/module.combodo-email-synchro.php
+++ b/module.combodo-email-synchro.php
@@ -61,6 +61,9 @@ SetupWebPage::AddModule(
 		'images_minimum_size' => '100x20', // Images smaller that these dimensions will be ignored (signatures...)
 		'images_maximum_size' => '', // Images bigger that these dimensions will be resized before uploading into iTop
 		'recommended_max_allowed_packet' => 10*1024*1024, // MySQL parameter for attachments
+		'auto_reply_header_patterns' => array (
+		  'auto-submitted' => '/^auto-replied.*$/i',
+		),
 	),
 	)
 );


### PR DESCRIPTION
With the new method it is possible to detect auto replies or auto generated mail by their header (see also [rfc3834](https://datatracker.ietf.org/doc/html/rfc3834#section-5))
 
This would be pretty useful in order to prevent sending automatic mails in reply to such messages (loop prevention). 
See also corresponding PR in [itop-standard-email-synchro](https://github.com/Combodo/itop-standard-email-synchro).