### PR TITLE
N°5094 Handle MOVE_MESSAGE code in debug log

### DIFF
--- a/classes/mailinboxesemailprocessor.class.inc.php
+++ b/classes/mailinboxesemailprocessor.class.inc.php
@@ -118,33 +118,33 @@ class MailInboxesEmailProcessor extends EmailProcessor
 	protected function GetActionFromCode($iRetCode)
 	{
 		$sRetCode = 'Unknown Code '.$iRetCode;
-		switch($iRetCode)
-		{
+		switch ($iRetCode) {
 			case EmailProcessor::NO_ACTION:
-			$sRetCode = 'NO_ACTION';
-			break;
-			
-			case EmailProcessor::DELETE_MESSAGE;
-			$sRetCode = 'DELETE_MESSAGE';
-			break;
-			
-			case EmailProcessor::PROCESS_MESSAGE:
-			$sRetCode = 'PROCESS_MESSAGE';
-			break;
-			
-			case EmailProcessor::PROCESS_ERROR:
-			$sRetCode = 'PROCESS_ERROR';
-			break;
-			
-			case EmailProcessor::MARK_MESSAGE_AS_ERROR:
-			$sRetCode = 'MARK_MESSAGE_AS_ERROR';
-			break;
+				$sRetCode = 'NO_ACTION';
+				break;
 
-            case EmailProcessor::MARK_MESSAGE_AS_UNDESIRED:
-            $sRetCode = 'MARK_MESSAGE_AS_UNDESIRED';
-            break;
+			case EmailProcessor::DELETE_MESSAGE;
+				$sRetCode = 'DELETE_MESSAGE';
+				break;
+
+			case EmailProcessor::PROCESS_MESSAGE:
+				$sRetCode = 'PROCESS_MESSAGE';
+				break;
+
+			case EmailProcessor::PROCESS_ERROR:
+				$sRetCode = 'PROCESS_ERROR';
+				break;
+
+			case EmailProcessor::MARK_MESSAGE_AS_ERROR:
+				$sRetCode = 'MARK_MESSAGE_AS_ERROR';
+				break;
+
+			case EmailProcessor::MARK_MESSAGE_AS_UNDESIRED:
+				$sRetCode = 'MARK_MESSAGE_AS_UNDESIRED';
+				break;
 		}
-		return $sRetCode;		
+
+		return $sRetCode;
 	}
 
 	/**

--- a/classes/mailinboxesemailprocessor.class.inc.php
+++ b/classes/mailinboxesemailprocessor.class.inc.php
@@ -142,6 +142,10 @@ class MailInboxesEmailProcessor extends EmailProcessor
 			case EmailProcessor::MARK_MESSAGE_AS_UNDESIRED:
 				$sRetCode = 'MARK_MESSAGE_AS_UNDESIRED';
 				break;
+
+			case EmailProcessor::MOVE_MESSAGE:
+				$sRetCode = 'MOVE_MESSAGE';
+				break;
 		}
 
 		return $sRetCode;


### PR DESCRIPTION
Thanks @jbostoen to have pointed out this default in https://sourceforge.net/p/itop/tickets/2039/

This PR adds in \MailInboxesEmailProcessor::GetActionFromCode the \EmailProcessor::MOVE_MESSAGE code. It was added in 3.4.0 (N°1674) but we forgot to add it here.
The consequence is that when logging with the debug option, we are not getting the correct code ("unknown code" instead of "move_message").