### PR TITLE
N° 2638 - Fix Attachments without Content should be processed

### DIFF
--- a/classes/emailmessage.class.inc.php
+++ b/classes/emailmessage.class.inc.php
@@ -115,10 +115,6 @@ class EmailMessage {
 			{
 				$aErrors[] = 'No attachment file name';
 			}
-			if (empty($aAttachment['content']))
-			{
-				$aErrors[] = 'No attachment content for '.$aAttachment['filename'];
-			}
 		}
 		return $aErrors;
 	}


### PR DESCRIPTION
Hi Combodo,

currently, if an incoming mail has one (or more) attachments, which are empty (`empty($aAttachment['content'])` returns true), the mail will be marked by iTop as "In Error". 

But actually, an empty file is nothing, which is considered faulty about an E-Mail and iTop does not crash when handline an empty attachment (I tested it just now).

In fact, it seems to be fairly common in automation to send mails with empty attachments, indicating success or failure for a certain job.

Can you think of any other reason to not process an E-Mail with an empty attachment?

Martin