### PR TITLE
N°8889 - 🩹 Updates regex to match the mail content id properly

### DIFF
--- a/classes/rawemailmessage.class.inc.php
+++ b/classes/rawemailmessage.class.inc.php
@@ -498,7 +498,7 @@ class RawEmailMessage
 		$aParsedParts = array();
 		$sContentType = isset($aHeaders['content-type']) ? $aHeaders['content-type'] : '';
 
-		if (($sContentType != '') && preg_match('/multipart(.*);.*?boundary="?([^"]+)"?/i', $sContentType, $aMatches))
+		if (($sContentType != '') && preg_match('/multipart(.*);.*?boundary="?([^";]+)"?/i', $sContentType, $aMatches))
 		{
 			$sBoundary = $aMatches[2];
 			if (empty($sBoundary))


### PR DESCRIPTION
Example of content-type not properly manage

Content-Type: multipart/related; boundary=_004_PARP264MB67443FFE96E5ACB5C06D04C3BEF2APARP264MB6744FRAP_; type="multipart/alternative"

<!--

IMPORTANT: Please follow the guidelines within this PR template before submitting it, it will greatly help us process your PR. 🙏

Any PRs not following the guidelines or with missing information will not be considered.

-->

## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thead / Another PR / Combodo ticket? | <!-- Put the URL -->
| Type of change?                                               | Bug fix 


## Symptom (bug) / Objective (enhancement)
<!--
If it's a bug
  - Explain the symptom in details
  - If possible put error messages, logs or screenshots (you can paste image directly in this editor).

If it's an enhancement
  - Describe what is blocking you, what is the objective with as much details as possible.
  - Add screenshots if it's related to UI.
-->


## Reproduction procedure (bug)
<!--
Remove this section only if it's NOT a bug.

Otherwise, explain step by step how to reproduce the issue on a standard iTop Community.

If it requires a custom datamodel, provide the minimal XML delta to reproduce it on a standard iTop Community.
-->

1. On 2.7.11-14870
2. With module combodo-email-synchro: version 3.7.2
3. With PHP 7.2.24
4. Receive a email from exchange platform (Hotmail, onPremise Exchange, ...)
5. This mail contents an inline image
6. The ticket create from this email appears empty (description)
7. Finally, the ticket created is useless.


## Cause (bug)
<!--
Remove this section only if it's NOT a bug.

Otherwise, explain what is the cause of the issue (where in the code and why)
-->
Example of content-type not properly managed in exchange mail with inline pictures.

```
Content-Type: multipart/related; boundary=_004_PARP264MB67443FFE96E5ACB5C06D04C3BEF2APARP264MB6744FRAP_; type="multipart/alternative"
```

original regex :
`if (($sContentType != '') && preg_match('/multipart(.*);.*?boundary="?([^"]+)"?/i', $sContentType, $aMatches))`
It gets this value `_004_PARP264MB67443FFE96E5ACB5C06D04C3BEF2APARP264MB6744FRAP_; type=`

## Proposed solution (bug and enhancement)
<!--
Explain in details how you are proposing to solve this:
  - What did you do in the code and why
  - If you changed something in the UI, put before / after screenshots (you can paste image directly in this editor)
-->
If you fix the regex with this :
`if (($sContentType != '') && preg_match('/multipart(.*);.*?boundary="?([^";]+)"?/i', $sContentType, $aMatches))`
It gets the attended value : `_004_PARP264MB67443FFE96E5ACB5C06D04C3BEF2APARP264MB6744FRAP_`


## Checklist before requesting a review
<!--
Don't remove these lines, check them once done.
-->
- [x] I have performed a self-review of my code
- [x] I have tested all changes I made on an iTop instance
- [ ] Would a unit test be relevant and have I added it?
- [x] Is the PR clear and detailed enough so anyone can understand without digging in the code?
