### PR TITLE
N°9583 - Fix crash when moving / deleting email from Gmail mailboxes with IMAP protocol

### DIFF
--- a/ajax.php
+++ b/ajax.php
@@ -200,11 +200,11 @@ function GetMailboxContent($oPage, $oInbox)
 }
 
 /**
- * Finds the message with the given UIDL identifier
+ * Finds the index of the message with the given UIDL identifier
  * @param array $aMessages The array returned by $oSource->GetListing()
  * @param string $sUIDL The UIDL to find
  * @param EmailSource $oSource
- * @return array|false The message data if found, false otherwise
+ * @return int|false The index of the message if found, false otherwise
  */
 function FindMessageIDFromUIDL($aMessages, $sUIDL, EmailSource $oSource)
 {

--- a/ajax.php
+++ b/ajax.php
@@ -206,13 +206,13 @@ function GetMailboxContent($oPage, $oInbox)
  * @param EmailSource $oSource
  * @return array|false The message data if found, false otherwise
  */
-function FindMessageDataFromUIDL($aMessages, $sUIDL, EmailSource $oSource)
+function FindMessageIDFromUIDL($aMessages, $sUIDL, EmailSource $oSource)
 {
 	$sKey = $sUIDL;
 	$sMultiSourceKey = substr($sUIDL, 1 + strlen($oSource->GetName())); // in Multisource mode the name of the source plus _ are prepended to the UIDL
 	foreach ($aMessages as $aData) {
 		if ((strcmp($sKey, $aData['uidl']) == 0) || (strcmp($sMultiSourceKey, $aData['uidl']) == 0)) {
-			return $aData;
+			return $aData['msg_id'] - 1; // As our message_id is 1 based, we make it 0 based to communicate with internal API
 		}
 	}
 	return false;
@@ -267,14 +267,10 @@ try {
 						$aReplicas[$sUIDL]->DBDelete();
 					}
 					if ($sOperation == 'mailbox_delete_messages') {
-						$aMessageData = FindMessageDataFromUIDL($aMessages, $sUIDL, $oSource);
-						if ($aMessageData !== false) {
+						$idx = FindMessageIDFromUIDL($aMessages, $sUIDL, $oSource);
+						if ($idx !== false) {
 							// Delete the actual email from the mailbox
-							if (is_int($aMessageData['msg_id'])) {
-								$oSource->DeleteMessage($aMessageData['msg_id']);
-							} else {
-								$oSource->DeleteMessage($aMessageData['uidl'], false);
-							}
+							$oSource->DeleteMessage($idx);
 						}
 					}
 				}

--- a/classes/emailsource.class.inc.php
+++ b/classes/emailsource.class.inc.php
@@ -1,4 +1,5 @@
 <?php
+
 // Copyright (C) 2016-2024 Combodo SAS
 //
 //   This program is free software; you can redistribute it and/or modify
@@ -19,7 +20,7 @@
  */
 
 /**
- * Exception triggered when encoutering messages too big to be read
+ * Exception triggered when encountering messages too big to be read
  */
 class EmailBiggerThanMaxMessageSizeException extends Exception
 {
@@ -37,7 +38,7 @@ class EmailBiggerThanMaxMessageSizeException extends Exception
 		parent::__construct($message, $code, $previous);
 		$this->iMessageSize = $iMessageSize;
 	}
-	
+
 	public function GetMessageSize()
 	{
 		return $this->iMessageSize;
@@ -59,20 +60,20 @@ abstract class EmailSource
 	 * @var int|float
 	 */
 	protected $maxMessageSize;
-	
+
 	public function __construct()
 	{
 		$this->sPartsOrder = 'text/plain,text/html'; // Default value can be changed via SetPartsOrder
-		$this->token  =null;
+		$this->token  = null;
 		$this->maxMessageSize = 0;
 	}
-	
+
 	/**
 	 * Get the number of messages to process
 	 * @return integer The number of available messages
 	 */
 	abstract public function GetMessagesCount();
-	
+
 	/**
 	 * Retrieves the message of the given index [0..Count]
 	 * @param $index integer The index between zero and count
@@ -136,8 +137,11 @@ abstract class EmailSource
 	abstract public function Disconnect();
 
 	/**
-	 * Workaround for some email servers (like gMail!) where the UID may change between two sessions, so let's use the MessageID
-	 * as a replacement for the UID !
+	 * Workaround for some email servers (like Gmail!) where the sequence number may change between two sessions, so let's use the MessageID
+	 * as a replacement for the sequence number!
+	 *
+	 * Up until we migrated from php_imap/laminas-mail library usage to ImapEngine, we used the sequence number instead of the UID and created
+	 * confusion in the code. We thought UID was able to mutate after an expunge, but it was the sequence number all along
 	 *
 	 * Note that it is possible to receive twice a message with the same MessageID, but since the content of the message
 	 * will be the same, it's a safe to process such messages only once...
@@ -162,7 +166,7 @@ abstract class EmailSource
 	{
 		return $this->sLastErrorMessage;
 	}
-	
+
 	/**
 	 * Preferred order for retrieving the mail "body" when scanning a multiparts emails
 	 * @param $sPartsOrder string A comma separated list of MIME types e.g. text/plain,text/html
@@ -183,35 +187,35 @@ abstract class EmailSource
 	 * Set an opaque reference token for use by the caller...
 	 * @param mixed $token
 	 */
- 	public function SetToken($token)
- 	{
- 		$this->token = $token;
- 	}
- 	/**
- 	 * Get the reference token set earlier....
- 	 * @return mixed The token set by SetToken()
- 	 */
- 	public function GetToken()
- 	{
- 		return $this->token;
- 	}
- 	
- 	/**
- 	 * Set the maximum size for a message (in byte)
- 	 * Messages larger than this value will not be read (will cause an EmailBiggerThanMaxMessageSizeException)
- 	 * @param int|float $maxMessageSize Could be an int if we are not on 32-bit system since 2Gb may be too small as a limit one day
- 	 */
- 	public function SetMaxMessageSize($maxMessageSize)
- 	{
- 		$this->maxMessageSize = $maxMessageSize;
- 	}
+	public function SetToken($token)
+	{
+		$this->token = $token;
+	}
+	/**
+	 * Get the reference token set earlier....
+	 * @return mixed The token set by SetToken()
+	 */
+	public function GetToken()
+	{
+		return $this->token;
+	}
 
- 	/**
- 	 * Get the maximum size set for reading messages
- 	 * @return int|float
- 	 */
- 	public function GetMaxMessageSize()
- 	{
- 		return $this->maxMessageSize;
- 	}
+	/**
+	 * Set the maximum size for a message (in byte)
+	 * Messages larger than this value will not be read (will cause an EmailBiggerThanMaxMessageSizeException)
+	 * @param int|float $maxMessageSize Could be an int if we are not on 32-bit system since 2Gb may be too small as a limit one day
+	 */
+	public function SetMaxMessageSize($maxMessageSize)
+	{
+		$this->maxMessageSize = $maxMessageSize;
+	}
+
+	/**
+	 * Get the maximum size set for reading messages
+	 * @return int|float
+	 */
+	public function GetMaxMessageSize()
+	{
+		return $this->maxMessageSize;
+	}
 }

--- a/src/Service/IMAPEmailSource.php
+++ b/src/Service/IMAPEmailSource.php
@@ -34,6 +34,7 @@ class IMAPEmailSource extends EmailSource
 	 */
 	private $oFolder;
 	private $bMessagesDeleted = false;
+	private array $aIndexedUids = [];
 
 	public function __construct(MailInboxBase $oMailbox)
 	{
@@ -90,22 +91,22 @@ class IMAPEmailSource extends EmailSource
 
 	public function GetMessage($index)
 	{
-		$iOffsetIndex = 1 + $index;
+		$iUid = $this->aIndexedUids[$index] ?? null;
 
-		IssueLog::Debug(__METHOD__." Start: $iOffsetIndex for $this->sServer", static::LOG_CHANNEL);
+		IssueLog::Debug(__METHOD__." Start: uid=$iUid index=$index for $this->sServer", static::LOG_CHANNEL);
 		try {
 			$oMessage = $this->GetFolder()
 				->messages()
 				->withHeaders()
 				->withBody()
-				->findOrFail($iOffsetIndex, ImapFetchIdentifier::MessageNumber);
+				->findOrFail($iUid, ImapFetchIdentifier::Uid);
 
 			if (!$oMessage) {
 				return null;
 			}
 			$sUIDL = static::UseMessageIdAsUid() ? $oMessage->messageId() : $oMessage->uid();
 		} catch (Exception $e) {
-			IssueLog::Error(__METHOD__." $iOffsetIndex for $this->sServer throws an exception", static::LOG_CHANNEL, [
+			IssueLog::Error(__METHOD__." uid=$iUid for $this->sServer throws an exception", static::LOG_CHANNEL, [
 				'exception.message' => $e->getMessage(),
 				'exception.stack'   => $e->getTraceAsString(),
 			]);
@@ -113,19 +114,23 @@ class IMAPEmailSource extends EmailSource
 			return null;
 		}
 		$oNewMail = new MessageFromMailbox($sUIDL, $oMessage->head(), $oMessage->body());
-		IssueLog::Debug(__METHOD__." End: $iOffsetIndex for $this->sServer", static::LOG_CHANNEL);
+		IssueLog::Debug(__METHOD__." End: uid=$iUid for $this->sServer", static::LOG_CHANNEL);
 
 		return $oNewMail;
 	}
 
 	/**
 	 * @param $index
-	 * @param bool $bMessageNumberAsIdentifier If true, the index is considered as the message number (1-based index), otherwise it is considered as the UID (0-based index)
+	 * @param bool $bMessageNumberAsIdentifier Ignored when a cached UID is available; kept for API compatibility.
 	 * @return true|null
 	 */
 	public function DeleteMessage($index, bool $bMessageNumberAsIdentifier = true)
 	{
-		if ($bMessageNumberAsIdentifier) {
+		$iCachedUid = $this->aIndexedUids[$index] ?? null;
+		if ($iCachedUid !== null) {
+			$iOffsetIndex = $iCachedUid;
+			$identifier = ImapFetchIdentifier::Uid;
+		} elseif ($bMessageNumberAsIdentifier) {
 			$iOffsetIndex = 1 + $index;
 			$identifier = ImapFetchIdentifier::MessageNumber;
 		} else {
@@ -171,15 +176,18 @@ class IMAPEmailSource extends EmailSource
 
 	public function GetListing()
 	{
+		$this->aIndexedUids = [];
 		$aReturn = [];
 		$oMessages = $this->GetFolder()
 			->messages()
 			->withHeaders()
 			->get();
 		foreach ($oMessages as $oMessage) {
+			$iUid = $oMessage->uid();
+			$this->aIndexedUids[] = $iUid;
 			$aReturn[] = [
 				'msg_id' => $oMessage->messageId(),
-				'uidl'   => static::UseMessageIdAsUid() ? $oMessage->messageId() : $oMessage->uid(),
+				'uidl'   => static::UseMessageIdAsUid() ? $oMessage->messageId() : $iUid,
 			];
 		}
 		return $aReturn;
@@ -206,12 +214,14 @@ class IMAPEmailSource extends EmailSource
 	 */
 	public function MoveMessage($index)
 	{
-		$iOffsetIndex = 1 + $index;
+		$iCachedUid = $this->aIndexedUids[$index] ?? null;
+		$iOffsetIndex = $iCachedUid ?? (1 + $index);
+		$identifier = $iCachedUid !== null ? ImapFetchIdentifier::Uid : ImapFetchIdentifier::MessageNumber;
 		IssueLog::Debug(__METHOD__." Start: $iOffsetIndex for $this->sServer", static::LOG_CHANNEL);
 		try {
 			$oMessage = $this->GetFolder()
 				->messages()
-				->find($iOffsetIndex, ImapFetchIdentifier::MessageNumber);
+				->find($iOffsetIndex, $identifier);
 
 			if (!$oMessage) {
 				return false;

--- a/src/Service/IMAPEmailSource.php
+++ b/src/Service/IMAPEmailSource.php
@@ -253,7 +253,7 @@ class IMAPEmailSource extends EmailSource
 
 	/**
 	 * Resolve a sequence index as an UID. If none is found in our index, we'll try to use it as a sequence index
-	 * bMessagesDeleted
+	 *
 	 * @param int $iSequenceIndex
 	 * @return array{0:int,1:ImapFetchIdentifier}
 	 */

--- a/src/Service/IMAPEmailSource.php
+++ b/src/Service/IMAPEmailSource.php
@@ -91,22 +91,22 @@ class IMAPEmailSource extends EmailSource
 
 	public function GetMessage($index)
 	{
-		$iUid = $this->aIndexedUids[$index] ?? null;
+		[$iOffsetIndex, $identifier] = $this->ResolveMessageIdentifier($index);
 
-		IssueLog::Debug(__METHOD__." Start: uid=$iUid index=$index for $this->sServer", static::LOG_CHANNEL);
+		IssueLog::Debug(__METHOD__." Start: uid=$iOffsetIndex index=$index for $this->sServer", static::LOG_CHANNEL);
 		try {
 			$oMessage = $this->GetFolder()
 				->messages()
 				->withHeaders()
 				->withBody()
-				->findOrFail($iUid, ImapFetchIdentifier::Uid);
+				->findOrFail($iOffsetIndex, $identifier);
 
 			if (!$oMessage) {
 				return null;
 			}
 			$sUIDL = static::UseMessageIdAsUid() ? $oMessage->messageId() : $oMessage->uid();
 		} catch (Exception $e) {
-			IssueLog::Error(__METHOD__." uid=$iUid for $this->sServer throws an exception", static::LOG_CHANNEL, [
+			IssueLog::Error(__METHOD__." uid=$iOffsetIndex for $this->sServer throws an exception", static::LOG_CHANNEL, [
 				'exception.message' => $e->getMessage(),
 				'exception.stack'   => $e->getTraceAsString(),
 			]);
@@ -114,29 +114,18 @@ class IMAPEmailSource extends EmailSource
 			return null;
 		}
 		$oNewMail = new MessageFromMailbox($sUIDL, $oMessage->head(), $oMessage->body());
-		IssueLog::Debug(__METHOD__." End: uid=$iUid for $this->sServer", static::LOG_CHANNEL);
+		IssueLog::Debug(__METHOD__." End: uid=$iOffsetIndex for $this->sServer", static::LOG_CHANNEL);
 
 		return $oNewMail;
 	}
 
 	/**
 	 * @param $index
-	 * @param bool $bMessageNumberAsIdentifier Ignored when a cached UID is available; kept for API compatibility.
 	 * @return true|null
 	 */
-	public function DeleteMessage($index, bool $bMessageNumberAsIdentifier = true)
+	public function DeleteMessage($index)
 	{
-		$iCachedUid = $this->aIndexedUids[$index] ?? null;
-		if ($iCachedUid !== null) {
-			$iOffsetIndex = $iCachedUid;
-			$identifier = ImapFetchIdentifier::Uid;
-		} elseif ($bMessageNumberAsIdentifier) {
-			$iOffsetIndex = 1 + $index;
-			$identifier = ImapFetchIdentifier::MessageNumber;
-		} else {
-			$iOffsetIndex = $index;
-			$identifier = ImapFetchIdentifier::Uid;
-		}
+		[$iOffsetIndex, $identifier] = $this->ResolveMessageIdentifier($index);
 
 		IssueLog::Debug(__METHOD__." Start: $iOffsetIndex for $this->sServer", static::LOG_CHANNEL);
 		try {
@@ -176,31 +165,35 @@ class IMAPEmailSource extends EmailSource
 
 	public function GetListing()
 	{
+		// Indexes the UIDs of the messages to communicate with the IMAP server with UID only (if we can)
+		// Internally iTop uses sequence number, we'll use this cache to map both
 		$this->aIndexedUids = [];
 		$aReturn = [];
 		$oMessages = $this->GetFolder()
 			->messages()
 			->withHeaders()
 			->get();
+
+		$iIndex = 1; // We start at 1 to be consistent with IMAP sequence index
 		foreach ($oMessages as $oMessage) {
 			$iUid = $oMessage->uid();
 			$this->aIndexedUids[] = $iUid;
 			$aReturn[] = [
-				'msg_id' => $oMessage->messageId(),
+				'msg_id' => $iIndex, // msg_id is historically not a messageId, but the sequence index
 				'uidl'   => static::UseMessageIdAsUid() ? $oMessage->messageId() : $iUid,
 			];
+			$iIndex++;
 		}
 		return $aReturn;
 	}
 
 	public function GetFolder()
 	{
-        if ($this->oFolder === null && $this->sMailbox === "") {
-            $this->oFolder = $this->oMailbox->inbox();
-        }
-        else if ($this->oFolder === null) {
-            $this->oFolder =  $this->oMailbox->folders()->find($this->sMailbox);
-        }
+		if ($this->oFolder === null && $this->sMailbox === "") {
+			$this->oFolder = $this->oMailbox->inbox();
+		} elseif ($this->oFolder === null) {
+			$this->oFolder =  $this->oMailbox->folders()->find($this->sMailbox);
+		}
 
 		return $this->oFolder;
 	}
@@ -214,9 +207,7 @@ class IMAPEmailSource extends EmailSource
 	 */
 	public function MoveMessage($index)
 	{
-		$iCachedUid = $this->aIndexedUids[$index] ?? null;
-		$iOffsetIndex = $iCachedUid ?? (1 + $index);
-		$identifier = $iCachedUid !== null ? ImapFetchIdentifier::Uid : ImapFetchIdentifier::MessageNumber;
+		[$iOffsetIndex, $identifier] = $this->ResolveMessageIdentifier($index);
 		IssueLog::Debug(__METHOD__." Start: $iOffsetIndex for $this->sServer", static::LOG_CHANNEL);
 		try {
 			$oMessage = $this->GetFolder()
@@ -227,7 +218,7 @@ class IMAPEmailSource extends EmailSource
 				return false;
 			}
 
-			// Use copy+delete instead of move as GMail won't expunge automatically and break our way of iterating over messages indexes
+			// Use copy+delete instead of move as Gmail won't expunge automatically and break our way of iterating over messages indexes
 			$oMessage->copy($this->sTargetFolder);
 			$oMessage->delete();
 			$this->bMessagesDeleted = true;
@@ -258,5 +249,22 @@ class IMAPEmailSource extends EmailSource
 	public function GetMailbox()
 	{
 		return $this->sMailbox;
+	}
+
+	/**
+	 * Resolve a sequence index as an UID. If none is found in our index, we'll try to use it as a sequence index
+	 * bMessagesDeleted
+	 * @param int $iSequenceIndex
+	 * @return array{0:int,1:ImapFetchIdentifier}
+	 */
+	private function ResolveMessageIdentifier(int $iSequenceIndex): array
+	{
+		$iCachedUid = $this->aIndexedUids[$iSequenceIndex] ?? null;
+		if ($iCachedUid !== null) {
+			return [$iCachedUid, ImapFetchIdentifier::Uid];
+		}
+
+		// Our internal API use 0 based sequence number, we make it 1 based to match IMAP RFC 9051 2.3.1.2.https://www.ietf.org/rfc/rfc9051.html#section-2.3.1.2
+		return [1 + $iSequenceIndex, ImapFetchIdentifier::MessageNumber];
 	}
 }

--- a/tests/php-unit-tests/unitary-tests/IMAPEmailSourceTest.php
+++ b/tests/php-unit-tests/unitary-tests/IMAPEmailSourceTest.php
@@ -1,0 +1,178 @@
+<?php
+
+/*
+ * @copyright   Copyright (C) 2010-2026 Combodo SAS
+ * @license     http://opensource.org/licenses/AGPL-3.0
+ */
+
+namespace Combodo\iTop\CombodoEmailSynchro\Test\UnitTest\Unitary;
+
+use Combodo\iTop\Extension\EmailSynchro\Service\IMAPEmailSource;
+use Combodo\iTop\Test\UnitTest\ItopTestCase;
+use DirectoryTree\ImapEngine\Testing\FakeFolder;
+use DirectoryTree\ImapEngine\Testing\FakeMailbox;
+use MessageFromMailbox;
+use MetaModel;
+use ReflectionClass;
+use ReflectionProperty;
+use utils;
+
+class IMAPEmailSourceTest extends ItopTestCase
+{
+	private $oConfig;
+	private $bOriginalUseMessageIdAsUid;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->oConfig = utils::GetConfig();
+		$this->bOriginalUseMessageIdAsUid = MetaModel::GetModuleSetting('combodo-email-synchro', 'use_message_id_as_uid', false);
+	}
+
+	protected function tearDown(): void
+	{
+		parent::tearDown();
+		$this->setUseMessageIdAsUid($this->bOriginalUseMessageIdAsUid);
+	}
+	protected function LoadRequiredItopFiles(): void
+	{
+		parent::LoadRequiredItopFiles();
+		$this->RequireOnceItopFile('env-production/combodo-email-synchro/classes/autoload.php');
+		$this->RequireOnceItopFile('env-production/combodo-email-synchro/tests/php-unit-tests/unitary-tests/classes/TestImapMessage.php');
+	}
+
+	public function testIndexedUidFromListing(): void
+	{
+		$aMessages = [
+			$this->makeMessage(100, '<id-100@example.com>', "Message-ID: <id-100@example.com>\r\n", "Body 100"),
+			$this->makeMessage(200, '<id-200@example.com>', "Message-ID: <id-200@example.com>\r\n", "Body 200"),
+			$this->makeMessage(300, '<id-300@example.com>', "Message-ID: <id-300@example.com>\r\n", "Body 300"),
+		];
+
+		$oSource = $this->makeSourceWithMessages($aMessages, 'Processed');
+
+		$aListing = $oSource->GetListing();
+		$this->assertCount(3, $aListing);
+
+		$aIndexedUids = $this->getProtectedProperty($oSource, 'aIndexedUids');
+		$iUidl = $aIndexedUids[0];
+		$sExpected = 100;
+		$this->assertEquals($sExpected, $iUidl);
+	}
+
+	/**
+	 * @dataProvider GetMessageUsesIndexedUidFromListingProvider
+	 */
+	public function testGetMessageUsesIndexedUidFromListing($bUseMessageIdAsUid, $sExpectedUid): void
+	{
+		$this->setUseMessageIdAsUid($bUseMessageIdAsUid);
+
+		$aMessages = [
+			$this->makeMessage(100, '<id-100@example.com>', "Message-ID: <id-100@example.com>\r\n", "Body 100"),
+			$this->makeMessage(200, '<id-200@example.com>', "Message-ID: <id-200@example.com>\r\n", "Body 200"),
+		];
+
+		$oSource = $this->makeSourceWithMessages($aMessages, 'Processed');
+
+		$aListing = $oSource->GetListing();
+		$this->assertCount(2, $aListing);
+
+		$oMessage = $oSource->GetMessage(0);
+		$this->assertInstanceOf(MessageFromMailbox::class, $oMessage);
+
+		$iUidl = $this->getProtectedProperty($oMessage, 'sUIDL');
+		$this->assertEquals($sExpectedUid, $iUidl);
+	}
+
+	public function GetMessageUsesIndexedUidFromListingProvider()
+	{
+		return [
+			'UseMessageId' => [
+				true,
+				'<id-100@example.com>',
+			],
+			'DoesntUseMessageId' => [
+				false,
+				100,
+			],
+		];
+	}
+
+	public function testDeleteMessageUsesIndexedUidFromListing(): void
+	{
+		$aMessages = [
+			$this->makeMessage(100, '<id-100@example.com>', "Message-ID: <id-100@example.com>\r\n", "Body 100"),
+			$this->makeMessage(200, '<id-200@example.com>', "Message-ID: <id-200@example.com>\r\n", "Body 200"),
+		];
+
+		$Source = $this->makeSourceWithMessages($aMessages, 'Processed');
+
+		$Source->GetListing();
+		$Result = $Source->DeleteMessage(1);
+
+		$this->assertTrue($Result);
+		$this->assertTrue($aMessages[1]->wasDeleted());
+		$this->assertFalse($aMessages[0]->wasDeleted());
+	}
+
+	public function testMoveMessageUsesIndexedUidFromListing(): void
+	{
+		$sMessages = [
+			$this->makeMessage(100, '<id-100@example.com>', "Message-ID: <id-100@example.com>\r\n", "Body 100"),
+			$this->makeMessage(200, '<id-200@example.com>', "Message-ID: <id-200@example.com>\r\n", "Body 200"),
+		];
+
+		$oSource = $this->makeSourceWithMessages($sMessages, 'Processed');
+
+		$oSource->GetListing();
+		$bResult = $oSource->MoveMessage(0);
+
+		$this->assertTrue($bResult);
+		$this->assertEquals('Processed', $sMessages[0]->copiedTo());
+		$this->assertTrue($sMessages[0]->wasDeleted());
+	}
+
+	private function makeSourceWithMessages(array $aMessages, string $sTargetFolder): IMAPEmailSource
+	{
+		$oFolder = new FakeFolder('inbox', messages: $aMessages);
+		$oMailbox = new FakeMailbox(folders: [$oFolder]);
+
+		$oRef = new ReflectionClass(IMAPEmailSource::class);
+		$oSource = $oRef->newInstanceWithoutConstructor();
+
+		$this->setProperty($oSource, 'sServer', 'test-server');
+		$this->setProperty($oSource, 'sLogin', 'test-user');
+		$this->setProperty($oSource, 'sMailbox', '');
+		$this->setProperty($oSource, 'sTargetFolder', $sTargetFolder);
+		$this->setProperty($oSource, 'oMailbox', $oMailbox);
+		$this->setProperty($oSource, 'oFolder', null);
+		$this->setProperty($oSource, 'bMessagesDeleted', false);
+		$this->setProperty($oSource, 'aIndexedUids', []);
+
+		return $oSource;
+	}
+
+	private function makeMessage(int $iUid, string $sMessageId, string $sHead, string $sBody): TestImapMessage
+	{
+		return new TestImapMessage($iUid, $sMessageId, $sHead, $sBody);
+	}
+
+	private function setProperty(object $oObj, string $sName, mixed $value): void
+	{
+		$prop = new ReflectionProperty($oObj, $sName);
+		$prop->setAccessible(true);
+		$prop->setValue($oObj, $value);
+	}
+
+	private function getProtectedProperty(object $oObj, string $sName): mixed
+	{
+		$prop = new ReflectionProperty($oObj, $sName);
+		$prop->setAccessible(true);
+		return $prop->getValue($oObj);
+	}
+
+	private function setUseMessageIdAsUid(bool $bUseMessageIdAsUid): void
+	{
+		$this->oConfig->SetModuleSetting('combodo-email-synchro', 'use_message_id_as_uid', $bUseMessageIdAsUid);
+	}
+}

--- a/tests/php-unit-tests/unitary-tests/classes/TestImapMessage.php
+++ b/tests/php-unit-tests/unitary-tests/classes/TestImapMessage.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * @copyright   Copyright (C) 2010-2026 Combodo SAS
+ * @license     http://opensource.org/licenses/AGPL-3.0
+ */
+
+namespace Combodo\iTop\CombodoEmailSynchro\Test\UnitTest\Unitary;
+
+use DirectoryTree\ImapEngine\Testing\FakeMessage;
+
+class TestImapMessage extends FakeMessage
+{
+	private string $messageId;
+	private string $head;
+	private string $body;
+	private array $copyTargets = [];
+	private bool $deleted = false;
+
+	public function __construct(int $uid, string $messageId, string $head, string $body)
+	{
+		parent::__construct($uid, [], $head."\r\n".$body);
+		$this->messageId = $messageId;
+		$this->head = $head;
+		$this->body = $body;
+	}
+
+	public function messageId(): ?string
+	{
+		return $this->messageId;
+	}
+
+	public function head(): string
+	{
+		return $this->head;
+	}
+
+	public function body(): string
+	{
+		return $this->body;
+	}
+
+	public function copy(string $folder): void
+	{
+		$this->copyTargets[] = $folder;
+	}
+
+	public function delete(bool $expunge = false): void
+	{
+		$this->deleted = true;
+	}
+
+	public function wasDeleted(): bool
+	{
+		return $this->deleted;
+	}
+
+	public function copiedTo(): ?string
+	{
+		return $this->copyTargets[0] ?? null;
+	}
+}


### PR DESCRIPTION
## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thread / Another PR / Combodo ticket? | N/A
| Type of change?                                               | Bug fix


## Symptom (bug)

When using a Gmail mailbox with the DELETE action, the cron process crashes mid-run with a fatal PHP error, leaving all remaining messages in the inbox unprocessed until the next cron cycle. Emails are eventually processed but require multiple cron runs and are not processed in order.

**Error log:**
```
Combodo\iTop\Extension\EmailSynchro\Service\IMAPEmailSource::GetMessage 2 for imap.gmail.com throws an exception
exception.message: (empty)
exception.stack:
  #0 MessageQuery.php(173): Collection->firstOrFail()
  #1 IMAPEmailSource.php(103): MessageQuery->findOrFail()
  #2 emailbackgroundprocess.class.inc.php(340): IMAPEmailSource->GetMessage()
  #3 cron.php(119): EmailBackgroundProcess->Process()

Uncaught Error: Call to a member function Decode() on null
  in emailbackgroundprocess.class.inc.php:342
```

## Reproduction procedure (bug)

1. On iTop 3.2.3
2. With module version 3.9.1
3. With PHP 8.1.2
4. Configure a mailbox using Gmail (imap.gmail.com) with OAuth authentication and the **Delete** action for processed messages
5. Send 2 or more emails to the mailbox at roughly the same time
6. Wait for the cron to run
7. Observe that only some emails are turned into tickets; the rest appear on the next cron run
8. Check the server error log and find the fatal error above

## Cause (bug)

Gmail silently purges messages flagged as `\Deleted` the moment the next IMAP command is issued on the same connection. After `DeleteMessage()` marks a message as deleted, the subsequent `GetMessage()` call sends a `FETCH` for the next sequence number. Because Gmail has already purged the deleted message and renumbered the remaining ones, that sequence number no longer exists. The IMAP server returns an empty response, `firstOrFail()` throws an `ItemNotFoundException`, which is caught in `GetMessage()` and silently converted to a `null` return. `EmailBackgroundProcess::Process()` then calls `->Decode()` on that null, producing a fatal `Error` (not catchable as `Exception`) that kills the entire cron process.

The existing `MoveMessage()` code already includes a comment acknowledging this Gmail behaviour (`// GMail won't expunge automatically...`) but the same guard was never applied to `GetMessage()` and `DeleteMessage()`.


## Proposed solution (bug and enhancement)

`GetListing()` now caches each message's IMAP UID indexed by its position in the listing. IMAP UIDs are permanent identifiers assigned by the server and are unaffected by other messages being purged or renumbered.

`GetMessage()`, `DeleteMessage()`, and `MoveMessage()` look up the cached UID by listing index and fetch via `ImapFetchIdentifier::Uid` instead of computing a 1-based sequence number from the array index. This makes all three operations stable regardless of what Gmail does between calls.

Only `src/Service/IMAPEmailSource.php` is changed.

**Before**

<img width="1302" height="335" alt="image" src="https://github.com/user-attachments/assets/7b069b55-8d69-4fdb-b59b-8121ffee1742" />

Tickets 1, 2 and 3 sent at the same time. Observe that tickets 1 and 3 are processed at 11:56, and ticket 2 is processed in the next cron cycle at 12:00. The order of tickets is also messed up. 

**After**

<img width="1299" height="561" alt="image" src="https://github.com/user-attachments/assets/fb14e605-3153-43b5-b3af-ca067d32e8c9" />

Notice all tickets are processed in order and at the same time. 

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have tested all changes I made on an iTop instance
- [x] Would a unit test be relevant and have I added it?
- [x] Is the PR clear and detailed enough so anyone can understand without digging in the code?

Do you want me to also add a unit test for this? 