### PR TITLE
N°9563 - Fix infinite loading icon in "Mailbox content" tab when incorrect folder set

### DIFF
--- a/src/Service/IMAPEmailSource.php
+++ b/src/Service/IMAPEmailSource.php
@@ -187,12 +187,14 @@ class IMAPEmailSource extends EmailSource
 
 	public function GetFolder()
 	{
-        if ($this->oFolder === null && $this->sMailbox === "") {
-            $this->oFolder = $this->oMailbox->inbox();
-        }
-        else if ($this->oFolder === null) {
-            $this->oFolder =  $this->oMailbox->folders()->find($this->sMailbox);
-        }
+		if ($this->oFolder === null && $this->sMailbox === '') {
+			$this->oFolder = $this->oMailbox->inbox();
+		} elseif ($this->oFolder === null) {
+			$this->oFolder = $this->oMailbox->folders()->find($this->sMailbox);
+			if ($this->oFolder === null) {
+				throw new Exception("IMAP folder '{$this->sMailbox}' not found on server {$this->sServer}. Please check the 'Mailbox (for IMAP)' field and make sure it follows RFC 3501 (https://www.rfc-editor.org/rfc/rfc3501.html#section-5.1)");
+			}
+		}
 
 		return $this->oFolder;
 	}

--- a/src/Service/IMAPEmailSource.php
+++ b/src/Service/IMAPEmailSource.php
@@ -187,13 +187,16 @@ class IMAPEmailSource extends EmailSource
 
 	public function GetFolder()
 	{
+		// Set the folder if not already done
 		if ($this->oFolder === null && $this->sMailbox === '') {
 			$this->oFolder = $this->oMailbox->inbox();
 		} elseif ($this->oFolder === null) {
 			$this->oFolder = $this->oMailbox->folders()->find($this->sMailbox);
-			if ($this->oFolder === null) {
-				throw new Exception("IMAP folder '{$this->sMailbox}' not found on server {$this->sServer}. Please check the 'Mailbox (for IMAP)' field and make sure it follows RFC 3501 (https://www.rfc-editor.org/rfc/rfc3501.html#section-5.1)");
-			}
+		}
+
+		// If we haven't found a real folder yet, throw an error
+		if ($this->oFolder === null) {
+			throw new Exception("IMAP folder '{$this->sMailbox}' not found on server {$this->sServer}. Please check the 'Mailbox (for IMAP)' field and make sure it follows RFC 3501 (https://www.rfc-editor.org/rfc/rfc3501.html#section-5.1)");
 		}
 
 		return $this->oFolder;

--- a/tests/php-unit-tests/unitary-tests/IMAPEmailSourceTest.php
+++ b/tests/php-unit-tests/unitary-tests/IMAPEmailSourceTest.php
@@ -1,0 +1,138 @@
+<?php
+
+/*
+ * @copyright   Copyright (C) 2010-2025 Combodo SAS
+ * @license     http://opensource.org/licenses/AGPL-3.0
+ */
+
+namespace Combodo\iTop\CombodoEmailSynchro\Test\UnitTest\Unitary;
+
+use Combodo\iTop\Extension\EmailSynchro\Service\IMAPEmailSource;
+use Combodo\iTop\Test\UnitTest\ItopTestCase;
+use DirectoryTree\ImapEngine\FolderInterface;
+use DirectoryTree\ImapEngine\FolderRepositoryInterface;
+use DirectoryTree\ImapEngine\MailboxInterface;
+use Exception;
+use ReflectionClass;
+
+/**
+ * @covers \Combodo\iTop\Extension\EmailSynchro\Service\IMAPEmailSource
+ */
+class IMAPEmailSourceTest extends ItopTestCase
+{
+	private const SERVER_HOST = 'imap.example.com';
+
+	/**
+	 * Creates an IMAPEmailSource instance without going through the constructor (which requires a real IMAP connection), and injects the given dependencies.
+	 */
+	private function MakeSource(string $sMailbox, MailboxInterface $oMockMailbox): IMAPEmailSource
+	{
+		$oSource = (new ReflectionClass(IMAPEmailSource::class))->newInstanceWithoutConstructor();
+
+		$this->SetNonPublicProperty($oSource, 'sServer', self::SERVER_HOST);
+		$this->SetNonPublicProperty($oSource, 'sMailbox', $sMailbox);
+		$this->SetNonPublicProperty($oSource, 'oFolder', null);
+		$this->SetNonPublicProperty($oSource, 'bMessagesDeleted', false);
+		$this->SetNonPublicProperty($oSource, 'oMailbox', $oMockMailbox);
+
+		return $oSource;
+	}
+
+	/**
+	 * When the mailbox field is empty, GetFolder() must return the server's INBOX and must never call folders()->find().
+	 *
+	 * @covers \Combodo\iTop\Extension\EmailSynchro\Service\IMAPEmailSource::GetFolder
+	 * @since N°9563
+	 */
+	public function testGetFolderReturnsDefaultInboxWhenMailboxFieldIsEmpty(): void
+	{
+		$oMockFolder = $this->createMock(FolderInterface::class);
+
+		$oMockMailbox = $this->createMock(MailboxInterface::class);
+		$oMockMailbox->expects($this->once())->method('inbox')->willReturn($oMockFolder);
+		$oMockMailbox->expects($this->never())->method('folders');
+
+		$oSource = $this->MakeSource('', $oMockMailbox);
+
+		$this->assertSame($oMockFolder, $oSource->GetFolder());
+	}
+
+	/**
+	 * When the mailbox field is set and the folder exists on the server, GetFolder() must return it and must never call inbox().
+	 *
+	 * @covers \Combodo\iTop\Extension\EmailSynchro\Service\IMAPEmailSource::GetFolder
+	 * @since N°9563
+	 */
+	public function testGetFolderReturnsFolderWhenMailboxFieldIsValid(): void
+	{
+		$sValidFolderPath = 'INBOX/valid-folder';
+
+		$oMockFolder = $this->createMock(FolderInterface::class);
+
+		$oMockFolders = $this->createMock(FolderRepositoryInterface::class);
+		$oMockFolders->expects($this->once())
+			->method('find')
+			->with($sValidFolderPath)
+			->willReturn($oMockFolder);
+
+		$oMockMailbox = $this->createMock(MailboxInterface::class);
+		$oMockMailbox->expects($this->never())->method('inbox');
+		$oMockMailbox->expects($this->once())->method('folders')->willReturn($oMockFolders);
+
+		$oSource = $this->MakeSource($sValidFolderPath, $oMockMailbox);
+
+		$this->assertSame($oMockFolder, $oSource->GetFolder());
+	}
+
+	/**
+	 * When the mailbox field is set but the folder does not exist on the server, GetFolder() must throw an Exception with the folder name and server in its message,
+	 * so the caller (and ultimately the user) gets an actionable error.
+	 *
+	 * This is the non regression test for the fatal "Call to a member function status() on null" that occurred when an invalid mailbox folder was configured.
+	 *
+	 * @covers \Combodo\iTop\Extension\EmailSynchro\Service\IMAPEmailSource::GetFolder
+	 * @since N°9563
+	 */
+	public function testGetFolderThrowsWhenMailboxFolderDoesNotExist(): void
+	{
+		$sInvalidFolderPath = 'invalid-folder';
+
+		$oMockFolders = $this->createMock(FolderRepositoryInterface::class);
+		$oMockFolders->method('find')->with($sInvalidFolderPath)->willReturn(null);
+
+		$oMockMailbox = $this->createMock(MailboxInterface::class);
+		$oMockMailbox->method('folders')->willReturn($oMockFolders);
+
+		$oSource = $this->MakeSource($sInvalidFolderPath, $oMockMailbox);
+
+		$this->expectException(Exception::class);
+		$this->expectExceptionMessageMatches('/'.$sInvalidFolderPath.'/');
+		$this->expectExceptionMessageMatches('/'.preg_quote(self::SERVER_HOST, '/').'/');
+
+		$oSource->GetFolder();
+	}
+
+	/**
+	 * GetFolder() must cache the FolderInterface after the first call. Subsequent calls must return the same instance without hitting the IMAP server again.
+	 *
+	 * @covers \Combodo\iTop\Extension\EmailSynchro\Service\IMAPEmailSource::GetFolder
+	 * @since N°9563
+	 */
+	public function testGetFolderCachesFolderAfterFirstCall(): void
+	{
+		$oMockFolder = $this->createMock(FolderInterface::class);
+
+		$oMockMailbox = $this->createMock(MailboxInterface::class);
+		// inbox() must be called exactly once regardless of how many times GetFolder() is called
+		$oMockMailbox->expects($this->once())->method('inbox')->willReturn($oMockFolder);
+
+		$oSource = $this->MakeSource('', $oMockMailbox);
+
+		$oFirstResult  = $oSource->GetFolder();
+		$oSecondResult = $oSource->GetFolder();
+		$oThirdResult  = $oSource->GetFolder();
+
+		$this->assertSame($oFirstResult, $oSecondResult);
+		$this->assertSame($oFirstResult, $oThirdResult);
+	}
+}


### PR DESCRIPTION
## Base information

| Question | Answer |
|---|---|
| Related to a SourceForge thread / Another PR / A GitHub Issue / Combodo ticket? | N°9563 |
| Type of change? | Bug fix |

## Symptom (bug)

When opening the **Mailbox content** tab of a mailbox object, the loading spinner runs indefinitely.

<img width="1595" height="260" alt="image" src="https://github.com/user-attachments/assets/bdea0c86-a46b-4f81-bc6d-7d429f41b365" />

Opening the browser developer tools (Network tab) reveals a failed HTTP request to `ajax.php`. The iTop server error log contains:

```
Uncaught Error: Call to a member function status() on null
  in env-production/combodo-email-synchro/src/Service/IMAPEmailSource.php:85
Stack trace:
  #0 ajax.php(58): IMAPEmailSource->GetMessagesCount()
  #1 ajax.php(245): GetMailboxContent()
  #2 {main}
thrown
```

## Reproduction procedure (bug)

1. On iTop Community 3.2.3
2. With extension **Mail to ticket automation** 3.9.0+
3. With a user having access to mailboxes (e.g. Administrator)
4. Create a mailbox (see documentation)
5. In the mailbox settings, set the **Mailbox (for IMAP)** field to an invalid value (e.g. `foo`)
6. Save
7. Open browser developer tools (F12) and go to the Network tab
8. Open the **Mailbox content** tab
9. Observe that the loading spinner runs indefinitely and the Network tab shows a failed request

## Cause (bug)

`GetFolder()` (line 188 of `IMAPEmailSource.php`) calls `$this->oMailbox->folders()->find($this->sMailbox)`, which returns `null` when the folder does not exist on the IMAP server. This `null` is silently stored in `$this->oFolder` and returned to the caller.

`GetMessagesCount()` then calls `$this->GetFolder()->status()` — i.e. `null->status()` — which triggers a fatal PHP `Error` (not an `Exception`). Because it is an `Error`, it bypasses the `catch (Exception $e)` block in `ajax.php` and is instead handled by the `register_shutdown_function` registered in `application/startup.inc.php`, which outputs a generic, non-actionable message to the browser.

All other callers of `GetFolder()` (`GetListing()`, `GetMessage()`, `MoveMessage()`, `Disconnect()`) are exposed to the same crash.

## Proposed solution (bug and enhancement)

Modify `IMAPEmailSource::GetFolder()` so that it **never silently sets `$oFolder` to `null`**. When `folders()->find()` returns `null` (folder not found), the method now throws an explicit `Exception` containing the folder name and server host, instead of storing the `null`.

```php
$this->oFolder = $this->oMailbox->folders()->find($this->sMailbox);
if ($this->oFolder === null) {
    throw new Exception("IMAP folder '{$this->sMailbox}' not found on server {$this->sServer}. Please check the 'Mailbox (for IMAP)' field.");
}
```

The existing `catch (Exception $e)` in `ajax.php` already handles this gracefully: it logs the error and displays a readable message in the **Mailbox content** tab. No changes to `ajax.php` are needed.

This fix protects all consumers of `GetFolder()` against invalid folder paths in a single place.

**Before** (with PHP error display enabled):
> `Call to a member function status() on null in IMAPEmailSource.php:85`

**After:**
> `Failed to initialize the mailbox: test@combodo.com. Reason: IMAP folder 'foo' not found on server imap.example.com. Please check the 'Mailbox (for IMAP)' field.`

## Checklist before requesting a review

- [X] I have performed a self-review of my code
- [X] I have tested all changes I made on an iTop instance
- [X] I have added a unit test, otherwise I have explained why I couldn't
- [X] Is the PR clear and detailed enough so anyone can understand without digging in the code?
