### PR TITLE
N°3393 N°9718 - Remove calls to deprecated files/classes

### DIFF
--- a/ajax.php
+++ b/ajax.php
@@ -26,14 +26,6 @@
 require_once('../../approot.inc.php');
 require_once(APPROOT.'/application/application.inc.php');
 
-//remove require itopdesignformat at the same time as version_compare(ITOP_DESIGN_LATEST_VERSION , '3.0') < 0
-if (!defined("ITOP_DESIGN_LATEST_VERSION")) {
-	require_once APPROOT.'setup/itopdesignformat.class.inc.php';
-}
-if (version_compare(ITOP_DESIGN_LATEST_VERSION, '3.0') < 0) {
-	require_once(APPROOT.'/application/ajaxwebpage.class.inc.php');
-}
-
 /**
  * @param \ajax_page $oPage
  * @param \MailInboxBase $oInbox
@@ -225,11 +217,7 @@ try {
 	require_once(APPROOT.'/application/loginwebpage.class.inc.php');
 	LoginWebPage::DoLogin(); // Check user rights and prompt if needed
 
-	if (version_compare(ITOP_DESIGN_LATEST_VERSION, '3.0') < 0) {
-		$oPage = new ajax_page('');
-	} else {
-		$oPage = new AjaxPage('');
-	}
+	$oPage = new AjaxPage('');
 
 	$sOperation = utils::ReadParam('operation', '');
 	$iMailInboxId = utils::ReadParam('id', 0, false, 'raw_data');

--- a/ajax.php
+++ b/ajax.php
@@ -26,6 +26,8 @@
 require_once('../../approot.inc.php');
 require_once(APPROOT.'/application/application.inc.php');
 
+use Combodo\iTop\Application\WebPage\AjaxPage;
+
 /**
  * @param \ajax_page $oPage
  * @param \MailInboxBase $oInbox

--- a/details.php
+++ b/details.php
@@ -24,6 +24,7 @@
 
 use Combodo\iTop\Application\UI\Base\Component\Panel\PanelUIBlockFactory;
 use Combodo\iTop\Application\UI\Base\Layout\UIContentBlock;
+use Combodo\iTop\Application\WebPage\iTopWebPage;
 
 require_once('../approot.inc.php');
 


### PR DESCRIPTION
<!--

IMPORTANT: Please follow the guidelines within this PR template before submitting it, it will greatly help us process your PR. 🙏

Any PRs not following the guidelines or with missing information will not be considered.

-->

## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thread / Another PR / Combodo ticket? | N°3393 N°9718
| Type of change?                                               | Bug fix

## Symptom (bug) / Objective (enhancement)
When displaying debug tab with iTop 3.3.0, an error appears where ajax.php tries to include deprecated (now removed) ajaxwebpage file


## Reproduction procedure (bug)

1. On iTop 3.3.0-dev
2. With latest mail to ticket version
3. Configure an OAuth 2 mailbox
5. On the mailbox, go to the "Debug" tab
6. See the error

## Cause (bug)
`ajaxwebpage.class.inc.php` file has been removed from iTop 3.3.
It's now time to retire compatibility with iTop 2.7 that this bit of code used


## Proposed solution (bug and enhancement)
Remove calls to 2.7 compatibility code


## Checklist before requesting a review
<!--
Don't remove these lines, check them once done.
-->
- [X] I have performed a self-review of my code
- [X] I have tested all changes I made on an iTop instance (test on 3.3 and 3.2)
- [X] Is the PR clear and detailed enough so anyone can understand without digging in the code?
